### PR TITLE
[Feature] #15 ViewController & ViewModel 정형화

### DIFF
--- a/ShowPot/ShowPot.xcodeproj/project.pbxproj
+++ b/ShowPot/ShowPot.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		7D3196422C133EC90015F88E /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D3196412C133EC90015F88E /* Environment.swift */; };
 		7D3E96282C061CD2003A6FA9 /* SampleUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D3E96272C061CD2003A6FA9 /* SampleUseCase.swift */; };
 		7D3E962A2C061DA3003A6FA9 /* SampleAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D3E96292C061DA3003A6FA9 /* SampleAPI.swift */; };
+		7D8574C12C187A1F0042F539 /* LoginViewHolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D8574C02C187A1F0042F539 /* LoginViewHolder.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -73,6 +74,7 @@
 		7D3196412C133EC90015F88E /* Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
 		7D3E96272C061CD2003A6FA9 /* SampleUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleUseCase.swift; sourceTree = "<group>"; };
 		7D3E96292C061DA3003A6FA9 /* SampleAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleAPI.swift; sourceTree = "<group>"; };
+		7D8574C02C187A1F0042F539 /* LoginViewHolder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewHolder.swift; sourceTree = "<group>"; };
 		9C5E3FD03EE9C1E9E373BB01 /* Pods-ShowPot.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ShowPot.debug.xcconfig"; path = "Target Support Files/Pods-ShowPot/Pods-ShowPot.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -119,6 +121,7 @@
 				7D1E5FB02C0A20A50012504D /* ViewController */,
 				7D1E5FB12C0A20AE0012504D /* ViewModel */,
 				7D1E5FB72C0A23B20012504D /* Coordinator */,
+				7D8574C22C187A230042F539 /* ViewHolder */,
 			);
 			path = Login;
 			sourceTree = "<group>";
@@ -409,6 +412,14 @@
 			path = UseCase;
 			sourceTree = "<group>";
 		};
+		7D8574C22C187A230042F539 /* ViewHolder */ = {
+			isa = PBXGroup;
+			children = (
+				7D8574C02C187A1F0042F539 /* LoginViewHolder.swift */,
+			);
+			path = ViewHolder;
+			sourceTree = "<group>";
+		};
 		B7FDDD5BC531B3291F217534 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -540,6 +551,7 @@
 				7D1E5FBA2C0A28080012504D /* MainTabCoordinator.swift in Sources */,
 				7D3E962A2C061DA3003A6FA9 /* SampleAPI.swift in Sources */,
 				7D29812F2C01F23400A619FB /* SavedViewController.swift in Sources */,
+				7D8574C12C187A1F0042F539 /* LoginViewHolder.swift in Sources */,
 				7D2981002C01E1D000A619FB /* AppDelegate.swift in Sources */,
 				7D2981372C01F25B00A619FB /* APIService.swift in Sources */,
 				7D1E5FB62C0A23AB0012504D /* LoginCoordinator.swift in Sources */,

--- a/ShowPot/ShowPot.xcodeproj/project.pbxproj
+++ b/ShowPot/ShowPot.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		7D1E5FB42C0A23700012504D /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D1E5FB32C0A23700012504D /* AppCoordinator.swift */; };
 		7D1E5FB62C0A23AB0012504D /* LoginCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D1E5FB52C0A23AB0012504D /* LoginCoordinator.swift */; };
 		7D1E5FBA2C0A28080012504D /* MainTabCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D1E5FB92C0A28080012504D /* MainTabCoordinator.swift */; };
+		7D21953F2C143AAA00A38D2B /* ViewModelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D21953E2C143AAA00A38D2B /* ViewModelType.swift */; };
+		7D2195412C143E8400A38D2B /* ViewHolderType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D2195402C143E8400A38D2B /* ViewHolderType.swift */; };
 		7D2981002C01E1D000A619FB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D2980FF2C01E1D000A619FB /* AppDelegate.swift */; };
 		7D2981022C01E1D000A619FB /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D2981012C01E1D000A619FB /* SceneDelegate.swift */; };
 		7D2981042C01E1D000A619FB /* MainTabViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D2981032C01E1D000A619FB /* MainTabViewController.swift */; };
@@ -44,6 +46,8 @@
 		7D1E5FB32C0A23700012504D /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
 		7D1E5FB52C0A23AB0012504D /* LoginCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginCoordinator.swift; sourceTree = "<group>"; };
 		7D1E5FB92C0A28080012504D /* MainTabCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabCoordinator.swift; sourceTree = "<group>"; };
+		7D21953E2C143AAA00A38D2B /* ViewModelType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelType.swift; sourceTree = "<group>"; };
+		7D2195402C143E8400A38D2B /* ViewHolderType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewHolderType.swift; sourceTree = "<group>"; };
 		7D2980FC2C01E1D000A619FB /* ShowPot.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ShowPot.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7D2980FF2C01E1D000A619FB /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7D2981012C01E1D000A619FB /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -248,6 +252,8 @@
 			isa = PBXGroup;
 			children = (
 				7D29811D2C01EB8A00A619FB /* BaseViewController.swift */,
+				7D21953E2C143AAA00A38D2B /* ViewModelType.swift */,
+				7D2195402C143E8400A38D2B /* ViewHolderType.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -546,6 +552,8 @@
 				7D29812D2C01F22B00A619FB /* FeaturedViewModel.swift in Sources */,
 				7D2981312C01F23C00A619FB /* SavedViewModel.swift in Sources */,
 				7D2981412C01F29D00A619FB /* SampleUI.swift in Sources */,
+				7D21953F2C143AAA00A38D2B /* ViewModelType.swift in Sources */,
+				7D2195412C143E8400A38D2B /* ViewHolderType.swift in Sources */,
 				7D29812B2C01F22300A619FB /* FeaturedViewController.swift in Sources */,
 				7D1E5FAF2C0A20A10012504D /* LoginViewModel.swift in Sources */,
 				7D2981332C01F24500A619FB /* SettingsViewController.swift in Sources */,

--- a/ShowPot/ShowPot/Presentation/Common/BaseViewController.swift
+++ b/ShowPot/ShowPot/Presentation/Common/BaseViewController.swift
@@ -7,8 +7,47 @@
 
 import Foundation
 import UIKit
+import class RxSwift.DisposeBag
 
-// TODO: Need to work
-class BaseViewController: UIViewController {
+protocol BaseViewControllerPorotocol where Self: UIViewController {
+    associatedtype ViewHolder: ViewHolderType
+    associatedtype ViewModel: ViewModelType
     
+    var viewHolder: ViewHolder { get }
+    var viewModel: ViewModel { get }
 }
+
+extension BaseViewControllerPorotocol {
+    func viewHolderConfigure() {
+        viewHolder.place(in: view)
+        viewHolder.configureConstraints(for: view)
+    }
+}
+
+class BaseViewController: UIViewController  {
+    
+    /// A dispose bag. 각 ViewController에 종속적이다.
+    final let disposeBag = DisposeBag()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // TODO: 로그 추가
+        setupStyles()
+        bind()
+    }
+    
+    // 빈 영역 터치시 키보드 dismiss를 위한 코드
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        view.endEditing(true)
+    }
+    
+    /// 현재 ViewController의 view 관련 설정 코드
+    ///
+    /// ***i.e.*** self.title = "title"
+    func setupStyles() { }
+    
+    /// ViewModel 바인딩에 필요한 코드
+    func bind() { }
+}
+
+typealias ViewController = BaseViewController & BaseViewControllerPorotocol

--- a/ShowPot/ShowPot/Presentation/Common/ViewHolderType.swift
+++ b/ShowPot/ShowPot/Presentation/Common/ViewHolderType.swift
@@ -1,0 +1,13 @@
+//
+//  ViewHolderType.swift
+//  ShowPot
+//
+//  Created by Daegeon Choi on 6/8/24.
+//
+
+import UIKit
+
+protocol ViewHolderType {
+    func place(in view: UIView)
+    func configureConstraints(for view: UIView)
+}

--- a/ShowPot/ShowPot/Presentation/Common/ViewModelType.swift
+++ b/ShowPot/ShowPot/Presentation/Common/ViewModelType.swift
@@ -1,0 +1,16 @@
+//
+//  ViewModelType.swift
+//  ShowPot
+//
+//  Created by Daegeon Choi on 6/8/24.
+//
+
+import Foundation
+
+protocol ViewModelType {
+    associatedtype Input
+    associatedtype Output
+    
+    @discardableResult
+    func transform(input: Input) -> Output
+}

--- a/ShowPot/ShowPot/Presentation/Scene/Login/Coordinator/LoginCoordinator.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Login/Coordinator/LoginCoordinator.swift
@@ -19,8 +19,7 @@ class LoginCoordinator: Coordinator {
     }
     
     func start() {
-        let viewController: LoginViewController = LoginViewController()
-        viewController.coordinator = self
+        let viewController: LoginViewController = LoginViewController(viewModel: LoginViewModel(coordinator: self))
         viewController.view.backgroundColor = .yellow
         
         self.navigationController.pushViewController(viewController, animated: true)

--- a/ShowPot/ShowPot/Presentation/Scene/Login/ViewController/LoginViewController.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Login/ViewController/LoginViewController.swift
@@ -15,57 +15,35 @@ import RxCocoa
 import SnapKit
 import Then
 
-final class LoginViewController: BaseViewController {
+final class LoginViewController: ViewController {
     
-    var coordinator: LoginCoordinator?
-    private let disposeBag = DisposeBag()
+    let viewHolder: LoginViewHolder = .init()
+    let viewModel: LoginViewModel
     
-    private let containerStackView = UIStackView().then {
-        $0.backgroundColor = .clear
-        $0.axis = .vertical
+    init(viewModel: LoginViewModel) {
+        self.viewModel = viewModel
+        
+        super.init(nibName: nil, bundle: nil)
     }
     
-    private let googleSignInButton = GIDSignInButton()
-    private let kakaoSignInButton = UIButton().then {
-        $0.setImage(UIImage(resource: .kakaoLoginMediumNarrow), for: .normal)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        setupLayouts()
-        setupConstraints()
-        setupStyles()
-        bind()
+        viewHolderConfigure()
     }
     
-    private func setupLayouts() {
-        view.addSubview(containerStackView)
-        _ = [googleSignInButton, kakaoSignInButton].map { containerStackView.addArrangedSubview($0) }
-    }
-    
-    private func setupConstraints() {
-        containerStackView.snp.makeConstraints {
-            $0.center.equalToSuperview()
-        }
-        
-        googleSignInButton.snp.makeConstraints {
-            $0.height.equalTo(50)
-        }
-        
-        kakaoSignInButton.snp.makeConstraints {
-            $0.height.equalTo(50)
-        }
-    }
-    
-    private func setupStyles() {
+    override func setupStyles() {
         
     }
     
-    private func bind() {
+    override func bind() {
         
         // TODO: 최대건 - 애플 계정 추가 및 Google clientID, URL Schemes xcconfig로 빼기
         
-        googleSignInButton.rx.controlEvent(.touchUpInside)
+        viewHolder.googleSignInButton.rx.controlEvent(.touchUpInside)
             .subscribe(with: self) { owner, _ in
                 GIDSignIn.sharedInstance.signIn(withPresenting: owner) { result, error in
                     guard error == nil else { return }
@@ -74,7 +52,7 @@ final class LoginViewController: BaseViewController {
             }
             .disposed(by: disposeBag)
         
-        kakaoSignInButton.rx.tap
+        viewHolder.kakaoSignInButton.rx.tap
             .subscribe(with: self) { owner, _ in
                 let loginClosure: (OAuthToken?, Error?) -> Void = { oauthToken, error in
                     guard error == nil else {

--- a/ShowPot/ShowPot/Presentation/Scene/Login/ViewHolder/LoginViewHolder.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Login/ViewHolder/LoginViewHolder.swift
@@ -1,0 +1,46 @@
+//
+//  LoginViewHolder.swift
+//  ShowPot
+//
+//  Created by Daegeon Choi on 6/11/24.
+//
+
+import Foundation
+import SnapKit
+import GoogleSignIn
+
+final class LoginViewHolder {
+    
+    let containerStackView = UIStackView().then {
+        $0.backgroundColor = .clear
+        $0.axis = .vertical
+    }
+    
+    let googleSignInButton = GIDSignInButton()
+    let kakaoSignInButton = UIButton().then {
+        $0.setImage(UIImage(resource: .kakaoLoginMediumNarrow), for: .normal)
+    }
+}
+
+extension LoginViewHolder: ViewHolderType {
+    
+    func place(in view: UIView) {
+        view.addSubview(containerStackView)
+        _ = [googleSignInButton, kakaoSignInButton].map { containerStackView.addArrangedSubview($0) }
+    }
+    
+    func configureConstraints(for view: UIView) {
+        containerStackView.snp.makeConstraints {
+            $0.center.equalToSuperview()
+        }
+        
+        googleSignInButton.snp.makeConstraints {
+            $0.height.equalTo(50)
+        }
+        
+        kakaoSignInButton.snp.makeConstraints {
+            $0.height.equalTo(50)
+        }
+    }
+    
+}

--- a/ShowPot/ShowPot/Presentation/Scene/Login/ViewModel/LoginViewModel.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Login/ViewModel/LoginViewModel.swift
@@ -6,3 +6,25 @@
 //
 
 import Foundation
+
+final class LoginViewModel: ViewModelType {
+    
+    var coordinator: Coordinator
+    
+    init(coordinator: Coordinator) {
+        self.coordinator = coordinator
+    }
+    
+    struct Input { 
+        
+    }
+    
+    struct Output { 
+        
+    }
+    
+    func transform(input: Input) -> Output {
+        
+        return Output()
+    }
+}


### PR DESCRIPTION
<!--- 
Pull Request 제목은 반드시 아래의 형식을 따라야 합니다.
[<Category>] <issue number> <description> (e.g. "[Feature] #123 새로운 제스쳐 추가") 
-->

## Describe
`MVVM` `ViewModel-Input & Output` `ViewHolder`등의 패턴을 적용하고 정형화하기 위한 작업 필요

## Works made
`ViewHolder` `ViewModel`관련 프로토콜과 `BaseViewController` 작업 추가

## Changes Made
- `ViewHolderType` 프로토콜 추가 (`ViewController`의 UI 구성 분리를 위한 로직)
- `ViewModelType` 프로토콜 추가 (`ViewModel`에서 `Input-Output` 구조 사용을 위한 프로토콜)

### As-Is
<!-- 작업 이전 동작하던 부분을 기재합니다 -->
**기존 로직**
- 별다른 구조나 프로토콜 요구 없이 `Coordinator`만 사용하도록 논의됨
- `BaseViewController`에서 별다른 동작이나 제한 없음

### To-BE
<!-- 작업 이후 변경된 부분을 기재합니다. -->
**변경 로직**
- `ViewHolderType`, `ViewModelType`을 추가하고 이를 모두 사용하는 `BaseViewControllerPorotocol` 생성
- `BaseViewController`에 공통으로 사용되는 `DisposeBag`, 키보드 자동 dismiss 동작, `bind()`, `setUpStyles()` 추가
- `typealias ViewController = BaseViewController & BaseViewControllerPorotocol`를 뷰컨에서 준수하도록 추가

- 위 변경사항을 기존 `Login`화면에 적용하여 구조 생성

## How to Test
- 코드상으로 확인
- 정상 빌드 및 작동 내용이 변경되었는지 확인

## Issues Resolved
- #15 
