### PR TITLE
[Feature] #25 폰트 관리를 위한 코드 추가

### DIFF
--- a/ShowPot/ShowPot.xcodeproj/project.pbxproj
+++ b/ShowPot/ShowPot.xcodeproj/project.pbxproj
@@ -54,6 +54,10 @@
 		7D3E96282C061CD2003A6FA9 /* SampleUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D3E96272C061CD2003A6FA9 /* SampleUseCase.swift */; };
 		7D3E962A2C061DA3003A6FA9 /* SampleAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D3E96292C061DA3003A6FA9 /* SampleAPI.swift */; };
 		7D8574C12C187A1F0042F539 /* LoginViewHolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D8574C02C187A1F0042F539 /* LoginViewHolder.swift */; };
+		7DEACE4C2C1ECC5200F37DA3 /* CustomFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DEACE4B2C1ECC5200F37DA3 /* CustomFont.swift */; };
+		7DEACE4E2C1ED00100F37DA3 /* LanguageFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DEACE4D2C1ED00100F37DA3 /* LanguageFont.swift */; };
+		7DEACE512C1ED95E00F37DA3 /* KRFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DEACE502C1ED95E00F37DA3 /* KRFont.swift */; };
+		7DEACE532C1ED96400F37DA3 /* ENFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DEACE522C1ED96400F37DA3 /* ENFont.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -109,6 +113,10 @@
 		7D3E96272C061CD2003A6FA9 /* SampleUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleUseCase.swift; sourceTree = "<group>"; };
 		7D3E96292C061DA3003A6FA9 /* SampleAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleAPI.swift; sourceTree = "<group>"; };
 		7D8574C02C187A1F0042F539 /* LoginViewHolder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewHolder.swift; sourceTree = "<group>"; };
+		7DEACE4B2C1ECC5200F37DA3 /* CustomFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomFont.swift; sourceTree = "<group>"; };
+		7DEACE4D2C1ED00100F37DA3 /* LanguageFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageFont.swift; sourceTree = "<group>"; };
+		7DEACE502C1ED95E00F37DA3 /* KRFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KRFont.swift; sourceTree = "<group>"; };
+		7DEACE522C1ED96400F37DA3 /* ENFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ENFont.swift; sourceTree = "<group>"; };
 		9C5E3FD03EE9C1E9E373BB01 /* Pods-ShowPot.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ShowPot.debug.xcconfig"; path = "Target Support Files/Pods-ShowPot/Pods-ShowPot.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -297,6 +305,7 @@
 				7D2981182C01E90A00A619FB /* UI */,
 				7D3196412C133EC90015F88E /* Environment.swift */,
 				70107B092C198E5100F32042 /* LogHelper.swift */,
+				7DEACE4F2C1ED8EE00F37DA3 /* Font */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -495,6 +504,17 @@
 			path = ViewHolder;
 			sourceTree = "<group>";
 		};
+		7DEACE4F2C1ED8EE00F37DA3 /* Font */ = {
+			isa = PBXGroup;
+			children = (
+				7DEACE4B2C1ECC5200F37DA3 /* CustomFont.swift */,
+				7DEACE4D2C1ED00100F37DA3 /* LanguageFont.swift */,
+				7DEACE502C1ED95E00F37DA3 /* KRFont.swift */,
+				7DEACE522C1ED96400F37DA3 /* ENFont.swift */,
+			);
+			path = Font;
+			sourceTree = "<group>";
+		};
 		B7FDDD5BC531B3291F217534 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -636,11 +656,13 @@
 				7D1E5FAD2C0A20950012504D /* LoginViewController.swift in Sources */,
 				7D2981042C01E1D000A619FB /* MainTabViewController.swift in Sources */,
 				7D29813D2C01F28100A619FB /* SampleResponse.swift in Sources */,
+				7DEACE512C1ED95E00F37DA3 /* KRFont.swift in Sources */,
 				7D29811E2C01EB8A00A619FB /* BaseViewController.swift in Sources */,
 				70107B0A2C198E5100F32042 /* LogHelper.swift in Sources */,
 				7D29813F2C01F29200A619FB /* Sample+Extension.swift in Sources */,
 				7D1E5FBA2C0A28080012504D /* MainTabCoordinator.swift in Sources */,
 				7D3E962A2C061DA3003A6FA9 /* SampleAPI.swift in Sources */,
+				7DEACE4C2C1ECC5200F37DA3 /* CustomFont.swift in Sources */,
 				7D29812F2C01F23400A619FB /* SavedViewController.swift in Sources */,
 				7D8574C12C187A1F0042F539 /* LoginViewHolder.swift in Sources */,
 				7D2981002C01E1D000A619FB /* AppDelegate.swift in Sources */,
@@ -648,6 +670,7 @@
 				7D1E5FB62C0A23AB0012504D /* LoginCoordinator.swift in Sources */,
 				7D29813B2C01F27B00A619FB /* SampleRequest.swift in Sources */,
 				70107B302C1D58C500F32042 /* UIFont+Extension.swift in Sources */,
+				7DEACE532C1ED96400F37DA3 /* ENFont.swift in Sources */,
 				7D2981022C01E1D000A619FB /* SceneDelegate.swift in Sources */,
 				7D3196422C133EC90015F88E /* Environment.swift in Sources */,
 				7D3E96282C061CD2003A6FA9 /* SampleUseCase.swift in Sources */,
@@ -658,6 +681,7 @@
 				7D2981412C01F29D00A619FB /* SampleUI.swift in Sources */,
 				7D21953F2C143AAA00A38D2B /* ViewModelType.swift in Sources */,
 				7D2195412C143E8400A38D2B /* ViewHolderType.swift in Sources */,
+				7DEACE4E2C1ED00100F37DA3 /* LanguageFont.swift in Sources */,
 				7D29812B2C01F22300A619FB /* FeaturedViewController.swift in Sources */,
 				7D1E5FAF2C0A20A10012504D /* LoginViewModel.swift in Sources */,
 				7D2981332C01F24500A619FB /* SettingsViewController.swift in Sources */,

--- a/ShowPot/ShowPot.xcodeproj/project.pbxproj
+++ b/ShowPot/ShowPot.xcodeproj/project.pbxproj
@@ -47,7 +47,6 @@
 		7D2981372C01F25B00A619FB /* APIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D2981362C01F25B00A619FB /* APIService.swift */; };
 		7D29813B2C01F27B00A619FB /* SampleRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D29813A2C01F27B00A619FB /* SampleRequest.swift */; };
 		7D29813D2C01F28100A619FB /* SampleResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D29813C2C01F28100A619FB /* SampleResponse.swift */; };
-		7D29813F2C01F29200A619FB /* Sample+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D29813E2C01F29200A619FB /* Sample+Extension.swift */; };
 		7D2981412C01F29D00A619FB /* SampleUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D2981402C01F29D00A619FB /* SampleUI.swift */; };
 		7D2981432C01F2C200A619FB /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 7D2981422C01F2C200A619FB /* Localizable.strings */; };
 		7D3196422C133EC90015F88E /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D3196412C133EC90015F88E /* Environment.swift */; };
@@ -104,7 +103,6 @@
 		7D2981362C01F25B00A619FB /* APIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIService.swift; sourceTree = "<group>"; };
 		7D29813A2C01F27B00A619FB /* SampleRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleRequest.swift; sourceTree = "<group>"; };
 		7D29813C2C01F28100A619FB /* SampleResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleResponse.swift; sourceTree = "<group>"; };
-		7D29813E2C01F29200A619FB /* Sample+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Sample+Extension.swift"; sourceTree = "<group>"; };
 		7D2981402C01F29D00A619FB /* SampleUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleUI.swift; sourceTree = "<group>"; };
 		7D2981422C01F2C200A619FB /* Localizable.strings */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; path = Localizable.strings; sourceTree = "<group>"; };
 		7D31963D2C1336A70015F88E /* ShowPot-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "ShowPot-Release.xcconfig"; sourceTree = "<group>"; };
@@ -321,7 +319,6 @@
 		7D2981192C01E91300A619FB /* Extension */ = {
 			isa = PBXGroup;
 			children = (
-				7D29813E2C01F29200A619FB /* Sample+Extension.swift */,
 				70107B2F2C1D58C500F32042 /* UIFont+Extension.swift */,
 			);
 			path = Extension;
@@ -659,7 +656,6 @@
 				7DEACE512C1ED95E00F37DA3 /* KRFont.swift in Sources */,
 				7D29811E2C01EB8A00A619FB /* BaseViewController.swift in Sources */,
 				70107B0A2C198E5100F32042 /* LogHelper.swift in Sources */,
-				7D29813F2C01F29200A619FB /* Sample+Extension.swift in Sources */,
 				7D1E5FBA2C0A28080012504D /* MainTabCoordinator.swift in Sources */,
 				7D3E962A2C061DA3003A6FA9 /* SampleAPI.swift in Sources */,
 				7DEACE4C2C1ECC5200F37DA3 /* CustomFont.swift in Sources */,

--- a/ShowPot/ShowPot/Common/Extension/Sample+Extension.swift
+++ b/ShowPot/ShowPot/Common/Extension/Sample+Extension.swift
@@ -1,8 +1,0 @@
-//
-//  Sample+Extension.swift
-//  ShowPot
-//
-//  Created by Daegeon Choi on 5/25/24.
-//
-
-import Foundation

--- a/ShowPot/ShowPot/Common/Extension/UIFont+Extension.swift
+++ b/ShowPot/ShowPot/Common/Extension/UIFont+Extension.swift
@@ -8,45 +8,22 @@
 import UIKit
 
 extension UIFont {
-  
-  enum Pretendard: String {
     
-    // black
-    case black = "Pretendard-Black"
-    
-    // bold
-    case extraBold = "Pretendard-ExtraBold"
-    case bold = "Pretendard-Bold"
-    case semiBold = "Pretendard-SemiBold"
-    
-    // medium
-    case medium = "Pretendard-Medium"
-    
-    // regular
-    case regular = "Pretendard-Regular"
-    
-    // light
-    case light = "Pretendard-Light"
-    case extraLight = "Pretendard-ExtraLight"
-    
-    // thin
-    case thin = "Pretendard-Thin"
-  }
-  
-  enum Oswald: String {
-      
-      // light
-      case extraLight = "Oswald-ExtraLight"
-      case light = "Oswald-Light"
-      
-      // medium
-      case medium = "Oswald-Medium"
-      
-      // regular
-      case regular = "Oswald-Regular"
-      
-      // bold
-      case bold = "Oswald-Bold"
-      case semiBold = "Oswald-SemiBold"
-  }
+    /**
+     미리 정의된 `CustomFont` `CustomFontStyle` 열거형을 사용해 원하는 폰트를 가져온다
+     - Parameters:
+        - font: 폰트 종류  (*i.e.* Pretendard, Osward)
+        - style: 폰트 스타일 (*i.e* regular, semibold)
+        - size: 폰트 크기
+     - Returns: {font}-{style} 이름의 폰트가 있는 경우 해당 폰트 반환, 폰트가 없는 경우 기본 시스템 폰트 반환
+     */
+    static func customFont(font: CustomFont, style: CustomFontStyle, size: CGFloat) -> UIFont {
+        
+        let customFontName: String = "\(font.rawValue)-\(style.rawValue)"
+        guard let font = UIFont(name: customFontName, size: size) else {
+            return UIFont.systemFont(ofSize: size)
+        }
+        
+        return font
+    }
 }

--- a/ShowPot/ShowPot/Common/Font/CustomFont.swift
+++ b/ShowPot/ShowPot/Common/Font/CustomFont.swift
@@ -1,0 +1,30 @@
+//
+//  Font.swift
+//  ShowPot
+//
+//  Created by Daegeon Choi on 6/16/24.
+//
+
+import Foundation
+
+// MARK: 커스텀 폰트 관리
+
+/// 커스텀 폰트 종류
+enum CustomFont: String {
+    case pretendard = "Pretendard"
+    case oswald = "oswald"
+}
+
+/// 커스텀 폰트의 스타일 종류
+/// - Warning: 폰트 종류에 따라 지원하지 않는 Style이 있을 수 있어 주의 요망
+enum CustomFontStyle: String {
+    case black = "Black"
+    case extraBold = "ExtraBold"
+    case bold = "Bold"
+    case semiBold = "SemiBold"
+    case medium = "Medium"
+    case regular = "Regular"
+    case light = "Light"
+    case extraLight = "ExtraLight"
+    case thin = "Thin"
+}

--- a/ShowPot/ShowPot/Common/Font/CustomFont.swift
+++ b/ShowPot/ShowPot/Common/Font/CustomFont.swift
@@ -12,7 +12,7 @@ import Foundation
 /// 커스텀 폰트 종류
 enum CustomFont: String {
     case pretendard = "Pretendard"
-    case oswald = "oswald"
+    case oswald = "Oswald"
 }
 
 /// 커스텀 폰트의 스타일 종류

--- a/ShowPot/ShowPot/Common/Font/ENFont.swift
+++ b/ShowPot/ShowPot/Common/Font/ENFont.swift
@@ -1,0 +1,23 @@
+//
+//  ENFont.swift
+//  ShowPot
+//
+//  Created by Daegeon Choi on 6/16/24.
+//
+
+import UIKit
+
+/// 영어 폰트 스타일
+enum ENFont: LanguageFont {
+    static var font: CustomFont = .oswald
+    static var lineHeight: CGFloat = 1.5
+    static var letterSpacing: CGFloat = 0.0
+    
+    // 디자인 시스템에 명시된 폰트
+    static let H0: UIFont = .customFont(font: font, style: .semiBold, size: 30)
+    static let H1: UIFont = .customFont(font: font, style: .semiBold, size: 24)
+    static let H2: UIFont = .customFont(font: font, style: .semiBold, size: 22)
+    static let H3: UIFont = .customFont(font: font, style: .semiBold, size: 20)
+    static let H4: UIFont = .customFont(font: font, style: .semiBold, size: 28)
+    static let H5: UIFont = .customFont(font: font, style: .semiBold, size: 16)
+}

--- a/ShowPot/ShowPot/Common/Font/KRFont.swift
+++ b/ShowPot/ShowPot/Common/Font/KRFont.swift
@@ -1,0 +1,26 @@
+//
+//  KRFont.swift
+//  ShowPot
+//
+//  Created by Daegeon Choi on 6/16/24.
+//
+
+import UIKit
+
+/// 한국어 폰트 스타일
+enum KRFont: LanguageFont {
+    static var font: CustomFont = .pretendard
+    static var lineHeight: CGFloat = 1.5
+    static var letterSpacing: CGFloat = -0.025
+    
+    // 디자인 시스템에 명시된 폰트
+    static let H0: UIFont = .customFont(font: font, style: .semiBold, size: 24)
+    static let H1: UIFont = .customFont(font: font, style: .semiBold, size: 20)
+    static let H2: UIFont = .customFont(font: font, style: .semiBold, size: 18)
+    static let B1_semibold: UIFont = .customFont(font: font, style: .semiBold, size: 16)
+    static let B1_regular: UIFont = .customFont(font: font, style: .regular, size: 16)
+    static let B2_semibold: UIFont = .customFont(font: font, style: .semiBold, size: 14)
+    static let B2_regular: UIFont = .customFont(font: font, style: .regular, size: 14)
+    static let B3_semibold: UIFont = .customFont(font: font, style: .semiBold, size: 12)
+    static let B3_regular: UIFont = .customFont(font: font, style: .regular, size: 12)
+}

--- a/ShowPot/ShowPot/Common/Font/LanguageFont.swift
+++ b/ShowPot/ShowPot/Common/Font/LanguageFont.swift
@@ -1,0 +1,22 @@
+//
+//  LanguageFont.swift
+//  ShowPot
+//
+//  Created by Daegeon Choi on 6/16/24.
+//
+
+import UIKit
+
+// MARK: 언어별 커스텀 폰트 지정 및 관리
+
+/// 언어별 폰트가 다르기 때문에 폰트, line height, letter spacing 값들을 관리하기 위한 프로토콜
+protocol LanguageFont {
+    /// 폰트 이름
+    static var font: CustomFont { get }
+    
+    /// AttributedString에 사용할 lineHeight
+    static var lineHeight: CGFloat { get }
+    
+    /// AttributedString에 사용할 letterSpacing
+    static var letterSpacing: CGFloat { get }
+}


### PR DESCRIPTION
<!--- 
Pull Request 제목은 반드시 아래의 형식을 따라야 합니다.
[<Category>] <issue number> <description> (e.g. "[Feature] #123 새로운 제스쳐 추가") 
-->

## Describe
- 프로젝트에서 한글/알파벳 여부에 따라 여러개의 폰트를 동시에 사용해야 하기 때문에 이를 효율적으로 관리하기 위한 수단 필요
- 디자인 시스템에서 지정한 특정 폰트 스타일 `H0` `H1` 등을 쉽게 사용하기 위한 방법 필요 

## Works made
- `CustomFont.swift` 폰트 이름과 스타일 정보를 열거형으로 지정, 이를 통해 지정된 폰트만 가져 올 수 있다
- `UIFont+Extension.swift` 폰트 이름과 스타일 열거형을 이용해 `UIFont`를 추출할 수 있는 extension 메서드
- `LanguageFont.swift` 언어별 폰트 설정 또는 관련값을 관리하도록 하는 프로토콜
- `KRFont.swift` `ENFont.swift` 언어별 폰트 및 관련값이 지정되어 있는 코드 파일

## How to Test
해당 코드 사용하여 테스트
```
let font: UIFont = KRFont.H0
```

## Issues Resolved
- #25 
<!-- 
연관된 이슈나 다른 PR이 있다면 적어줍니다. '#123' 처럼 이슈 번호만 적지 말고, 이슈 타이틀이 같이 보일 수 있도록 bulletin list로 작성합니다.
e.g.
 - #123
 - #124
-->

## Additional context
- 향후 `AttributedString`이나 `UILabel`에 `line height`와 `letter spacing`을 효율적으로 적용할 방법 개발 필요

## References
- [How to deal with custom fonts in Swift and SwiftUI](https://medium.com/@paereson/how-to-deal-with-custom-fonts-in-swift-and-swiftui-f7886a824ac8)
