### PR TITLE
[Refactor] #20 기존 Common 로그 코드 개선

### DIFF
--- a/ShowPot/ShowPot/Presentation/Common/BaseViewController.swift
+++ b/ShowPot/ShowPot/Presentation/Common/BaseViewController.swift
@@ -29,9 +29,13 @@ class BaseViewController: UIViewController  {
     /// A dispose bag. 각 ViewController에 종속적이다.
     final let disposeBag = DisposeBag()
     
+    deinit {
+        LogHelper.debug("called \(self)")
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-        // TODO: 로그 추가
+        LogHelper.debug("called \(self)")
         setupStyles()
         bind()
     }

--- a/ShowPot/ShowPot/Presentation/Scene/Login/ViewController/LoginViewController.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Login/ViewController/LoginViewController.swift
@@ -30,13 +30,8 @@ final class LoginViewController: ViewController {
         fatalError("init(coder:) has not been implemented")
     }
     
-    deinit {
-        LogHelper.debug("called")
-    }
-    
     override func viewDidLoad() {
         super.viewDidLoad()
-        LogHelper.debug("called")
         viewHolderConfigure()
     }
     


### PR DESCRIPTION
## Describe
기존 ViewController 초기화 및 해제에 따른 로그 코드 개선

## Works made
* ViewController 초기화 및 해제에 대한 코드를 BaseViewController로 이동

## Changes Made
### As-Is
<!-- 작업 이전 동작하던 부분을 기재합니다 -->
**기존 로직**
* ViewController 초기화 및 해제에 대한 로그를 위해서 원하는 ViewController마다 해당 코드를 작성해야하는 번거로움 존재

**기존 코드 및 로그**
``` swift
/// LoginViewController
deinit {
        LogHelper.debug("called")
}

override func viewDidLoad() {
    super.viewDidLoad()
    LogHelper.debug("called")
    viewHolderConfigure()
}

/// Xcode console
[ShowPot/LoginViewController.swift:39] viewDidLoad() called
```

### To-BE
<!-- 작업 이후 변경된 부분을 기재합니다. -->
**변경 로직**
* BaseViewController에 ViewController 초기화 및 해제에 대한 로그를 이전함으로써 추가된 ViewController마다 번거롭게 추가하지않아도 디버그 가능

**변경 코드 및 로그**
``` swift
/// BaseViewController
deinit {
        LogHelper.debug("called \(self)")
}

override func viewDidLoad() {
    super.viewDidLoad()
    LogHelper.debug("called \(self)")
    setupStyles()
    bind()
}

/// Xcode console
[ShowPot/BaseViewController.swift:38] viewDidLoad() called <ShowPot.LoginViewController: 0x11701eb10>
```

## How to Test
* Xcode 콘솔에 찍힌 ViewController에 대한 초기화 및 해제에 대한 로그 확인

## Issues Resolved
- #20 