### PR TITLE
[Config] #8 Localizable을 SwiftGen이용해 자동화 설정

### DIFF
--- a/ShowPot/ShowPot.xcodeproj/project.pbxproj
+++ b/ShowPot/ShowPot.xcodeproj/project.pbxproj
@@ -73,6 +73,8 @@
 		7D3196422C133EC90015F88E /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D3196412C133EC90015F88E /* Environment.swift */; };
 		7D3E96282C061CD2003A6FA9 /* SampleUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D3E96272C061CD2003A6FA9 /* SampleUseCase.swift */; };
 		7D3E962A2C061DA3003A6FA9 /* SampleAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D3E96292C061DA3003A6FA9 /* SampleAPI.swift */; };
+		7D8255A52C295DF100D104BE /* swiftgen.yml in Resources */ = {isa = PBXBuildFile; fileRef = 7D8255A42C295DF100D104BE /* swiftgen.yml */; };
+		7D8255A72C295E3A00D104BE /* Strings+Generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D8255A62C295E3A00D104BE /* Strings+Generated.swift */; };
 		7D8574C12C187A1F0042F539 /* LoginViewHolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D8574C02C187A1F0042F539 /* LoginViewHolder.swift */; };
 		7DEACE4C2C1ECC5200F37DA3 /* CustomFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DEACE4B2C1ECC5200F37DA3 /* CustomFont.swift */; };
 		7DEACE4E2C1ED00100F37DA3 /* LanguageFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DEACE4D2C1ED00100F37DA3 /* LanguageFont.swift */; };
@@ -129,6 +131,8 @@
 		7D3196412C133EC90015F88E /* Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
 		7D3E96272C061CD2003A6FA9 /* SampleUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleUseCase.swift; sourceTree = "<group>"; };
 		7D3E96292C061DA3003A6FA9 /* SampleAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleAPI.swift; sourceTree = "<group>"; };
+		7D8255A42C295DF100D104BE /* swiftgen.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; path = swiftgen.yml; sourceTree = "<group>"; };
+		7D8255A62C295E3A00D104BE /* Strings+Generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Strings+Generated.swift"; sourceTree = "<group>"; };
 		7D8574C02C187A1F0042F539 /* LoginViewHolder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewHolder.swift; sourceTree = "<group>"; };
 		7DEACE4B2C1ECC5200F37DA3 /* CustomFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomFont.swift; sourceTree = "<group>"; };
 		7DEACE4D2C1ED00100F37DA3 /* LanguageFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageFont.swift; sourceTree = "<group>"; };
@@ -257,6 +261,7 @@
 		7D2980F32C01E1D000A619FB = {
 			isa = PBXGroup;
 			children = (
+				7D8255A42C295DF100D104BE /* swiftgen.yml */,
 				7D2980FE2C01E1D000A619FB /* ShowPot */,
 				7D2980FD2C01E1D000A619FB /* Products */,
 			);
@@ -356,6 +361,7 @@
 			isa = PBXGroup;
 			children = (
 				7D2981422C01F2C200A619FB /* Localizable.strings */,
+				7D8255A62C295E3A00D104BE /* Strings+Generated.swift */,
 			);
 			path = Localizable;
 			sourceTree = "<group>";
@@ -639,6 +645,7 @@
 				70107B282C1D573900F32042 /* Oswald-Light.ttf in Resources */,
 				70107B1C2C1D53FB00F32042 /* Pretendard-ExtraBold.otf in Resources */,
 				70107B2B2C1D573900F32042 /* Oswald-Regular.ttf in Resources */,
+				7D8255A52C295DF100D104BE /* swiftgen.yml in Resources */,
 				70107B2A2C1D573900F32042 /* Oswald-Medium.ttf in Resources */,
 				70107B202C1D53FB00F32042 /* Pretendard-Thin.otf in Resources */,
 				70107B192C1D53FB00F32042 /* Pretendard-Medium.otf in Resources */,
@@ -683,6 +690,7 @@
 				7D3E96282C061CD2003A6FA9 /* SampleUseCase.swift in Sources */,
 				7D1E5FB42C0A23700012504D /* AppCoordinator.swift in Sources */,
 				7D2981352C01F25100A619FB /* SettingViewModel.swift in Sources */,
+				7D8255A72C295E3A00D104BE /* Strings+Generated.swift in Sources */,
 				7D29812D2C01F22B00A619FB /* FeaturedViewModel.swift in Sources */,
 				7D2981312C01F23C00A619FB /* SavedViewModel.swift in Sources */,
 				7D2981412C01F29D00A619FB /* SampleUI.swift in Sources */,

--- a/ShowPot/ShowPot.xcodeproj/project.pbxproj
+++ b/ShowPot/ShowPot.xcodeproj/project.pbxproj
@@ -618,7 +618,6 @@
 				70107B4F2C21680400F32042 /* XCRemoteSwiftPackageReference "Then" */,
 				70107B572C21693E00F32042 /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */,
 				70107B5C2C216A4200F32042 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */,
-				70107B8D2C22A76B00F32042 /* XCRemoteSwiftPackageReference "SwiftGenPlugin" */,
 				7D2DCAB72C269BF700389FBF /* XCRemoteSwiftPackageReference "Alamofire" */,
 				7D2DCABA2C269C2100389FBF /* XCRemoteSwiftPackageReference "RxSwift" */,
 				7D2DCAC12C269C2E00389FBF /* XCRemoteSwiftPackageReference "SnapKit" */,
@@ -947,14 +946,6 @@
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 2.22.2;
-			};
-		};
-		70107B8D2C22A76B00F32042 /* XCRemoteSwiftPackageReference "SwiftGenPlugin" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/SwiftGen/SwiftGenPlugin";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 6.6.2;
 			};
 		};
 		7D1092242C26F36800498C87 /* XCRemoteSwiftPackageReference "FlexLayout" */ = {

--- a/ShowPot/ShowPot/Resource/Localizable/Localizable.strings
+++ b/ShowPot/ShowPot/Resource/Localizable/Localizable.strings
@@ -5,3 +5,5 @@
   Created by Daegeon Choi on 5/25/24.
   
 */
+
+"app_name" = "쇼팟";

--- a/ShowPot/ShowPot/Resource/Localizable/Strings+Generated.swift
+++ b/ShowPot/ShowPot/Resource/Localizable/Strings+Generated.swift
@@ -1,0 +1,41 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+import Foundation
+
+// swiftlint:disable superfluous_disable_command file_length implicit_return prefer_self_in_static_references
+
+// MARK: - Strings
+
+// swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length
+// swiftlint:disable nesting type_body_length type_name vertical_whitespace_opening_braces
+public enum Strings {
+  /// Localizable.strings
+  ///   ShowPot
+  /// 
+  ///   Created by Daegeon Choi on 5/25/24.
+  public static let appName = Strings.tr("Localizable", "app_name", fallback: "쇼팟")
+}
+// swiftlint:enable explicit_type_interface function_parameter_count identifier_name line_length
+// swiftlint:enable nesting type_body_length type_name vertical_whitespace_opening_braces
+
+// MARK: - Implementation Details
+
+extension Strings {
+  private static func tr(_ table: String, _ key: String, _ args: CVarArg..., fallback value: String) -> String {
+    let format = BundleToken.bundle.localizedString(forKey: key, value: value, table: table)
+    return String(format: format, locale: Locale.current, arguments: args)
+  }
+}
+
+// swiftlint:disable convenience_type
+private final class BundleToken {
+  static let bundle: Bundle = {
+    #if SWIFT_PACKAGE
+    return Bundle.module
+    #else
+    return Bundle(for: BundleToken.self)
+    #endif
+  }()
+}
+// swiftlint:enable convenience_type

--- a/ShowPot/swiftgen.yml
+++ b/ShowPot/swiftgen.yml
@@ -1,0 +1,12 @@
+input_dir: ShowPot/Resource
+output_dir: ShowPot/Resource
+
+strings:
+  inputs:
+    - Localizable/Localizable.strings
+  outputs:
+    - templateName: structured-swift5
+      output: Localizable/Strings+Generated.swift
+      params:
+        publicAccess: true
+        enumName: Strings


### PR DESCRIPTION
<!--- 
Pull Request 제목은 반드시 아래의 형식을 따라야 합니다.
[<Category>] <issue number> <description> (e.g. "[Feature] #123 새로운 제스쳐 추가") 
-->

## Describe
문구를 `Localizable.strings` 파일에 명시한 뒤, `SwiftGen`을 이용해 코드를 자동 생성하여 개발시 사용할 수 있는 환경 구성

## Works made
- 기존 SPM에 등록되어있던 `swiftGenPlugin` 제거
- configuration 설정 파일인 `swiftgen.yml` 추가
- 개인 PC에서 `Homebrew`를 통해 `SwiftGen` 설치 후 프로젝트 에서 실행하여 코드 자동 생성 후 등록

## How to Test
- `Homebrew`또는 `mint`를 통해 맥에 `SwiftGen` 설치
- 터미널에서 해당 프로젝트 최상위 디렉토리 (`24th-App-Team-3-iOS/ShowPot`)로 이동
- `swiftgen` 명령어 실행
- Strings+Generated.swift` 파일 변경 확인

## Issues Resolved
- #8 
<!-- 
연관된 이슈나 다른 PR이 있다면 적어줍니다. '#123' 처럼 이슈 번호만 적지 말고, 이슈 타이틀이 같이 보일 수 있도록 bulletin list로 작성합니다.
e.g.
 - #123
 - #124
-->

## References
- 설치 가이드: [SwiftGen - Installation](https://github.com/YAPP-Github/24th-App-Team-3-iOS/compare/develop...config/%238-swiftgen-localize?expand=1#installation)
- `.yml` 파일 구조: [SwiftGen  - Configuration File](https://github.com/YAPP-Github/24th-App-Team-3-iOS/compare/develop...config/%238-swiftgen-localize?expand=1#configuration-file)
