### PR TITLE
[Refactor] #25 피그마 잘못된 녹색 색상 기재로 인한 변경

### DIFF
--- a/ShowPot/ShowPot/Resource/Assets.xcassets/Color/Primary_Brand_Color/mainGreen.colorset/Contents.json
+++ b/ShowPot/ShowPot/Resource/Assets.xcassets/Color/Primary_Brand_Color/mainGreen.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x70",
-          "green" : "0x68",
-          "red" : "0x3F"
+          "blue" : "0x5A",
+          "green" : "0x8B",
+          "red" : "0x28"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x70",
-          "green" : "0x68",
-          "red" : "0x3F"
+          "blue" : "0x5A",
+          "green" : "0x8B",
+          "red" : "0x28"
         }
       },
       "idiom" : "universal"


### PR DESCRIPTION
## Describe
- 피그마에 디자이너분들의 의도와 다른 녹색 색상 기재로 옳은 색상으로 변경

## Works made
- 기존 `mainGreen`색상의 코드를 #288B5A로 수정하였습니다.
 
## How to Test
- Color Asset의 `mainGreen`색상의 코드 확인

## Issues Resolved
- #25 

## Additional context
[기존 mainGreen색상 코드 수정 요청 스레드 링크](https://discord.com/channels/1241701172532744202/1241703143968870410/1254363754833907733)