### PR TITLE
[Feature] #37 폰트에 따른 letterSpacing, lineHeight값 조절을 위한 Extention함수 구현

### DIFF
--- a/ShowPot/ShowPot.xcodeproj/project.pbxproj
+++ b/ShowPot/ShowPot.xcodeproj/project.pbxproj
@@ -40,7 +40,7 @@
 		70107B722C216A4200F32042 /* KakaoSDKTemplate in Frameworks */ = {isa = PBXBuildFile; productRef = 70107B712C216A4200F32042 /* KakaoSDKTemplate */; };
 		70107B742C216A4200F32042 /* KakaoSDKUser in Frameworks */ = {isa = PBXBuildFile; productRef = 70107B732C216A4200F32042 /* KakaoSDKUser */; };
 		70107B912C2E537E00F32042 /* UILabel+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70107B902C2E537E00F32042 /* UILabel+Extension.swift */; };
-		70107BA12C36661200F32042 /* NSMutableAttributedString+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70107BA02C36661200F32042 /* NSMutableAttributedString+Extension.swift */; };
+		70107BA12C36661200F32042 /* NSAttributedString+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70107BA02C36661200F32042 /* NSAttributedString+Extension.swift */; };
 		7D1092262C26F36800498C87 /* FlexLayout in Frameworks */ = {isa = PBXBuildFile; productRef = 7D1092252C26F36800498C87 /* FlexLayout */; };
 		7D1092292C26F38800498C87 /* PinLayout in Frameworks */ = {isa = PBXBuildFile; productRef = 7D1092282C26F38800498C87 /* PinLayout */; };
 		7D13C3522C35A8A30017AE93 /* MainTabController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D13C3512C35A8A30017AE93 /* MainTabController.swift */; };
@@ -108,9 +108,9 @@
 		70107B252C1D573900F32042 /* Oswald-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Oswald-Regular.ttf"; sourceTree = "<group>"; };
 		70107B262C1D573900F32042 /* Oswald-SemiBold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Oswald-SemiBold.ttf"; sourceTree = "<group>"; };
 		70107B2F2C1D58C500F32042 /* UIFont+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+Extension.swift"; sourceTree = "<group>"; };
-		7D13C3512C35A8A30017AE93 /* MainTabController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabController.swift; sourceTree = "<group>"; };
 		70107B902C2E537E00F32042 /* UILabel+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+Extension.swift"; sourceTree = "<group>"; };
-		70107BA02C36661200F32042 /* NSMutableAttributedString+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSMutableAttributedString+Extension.swift"; sourceTree = "<group>"; };
+		70107BA02C36661200F32042 /* NSAttributedString+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+Extension.swift"; sourceTree = "<group>"; };
+		7D13C3512C35A8A30017AE93 /* MainTabController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabController.swift; sourceTree = "<group>"; };
 		7D1E5FAC2C0A20950012504D /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		7D1E5FAE2C0A20A10012504D /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
 		7D1E5FB32C0A23700012504D /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
@@ -346,7 +346,7 @@
 			children = (
 				70107B2F2C1D58C500F32042 /* UIFont+Extension.swift */,
 				70107B902C2E537E00F32042 /* UILabel+Extension.swift */,
-				70107BA02C36661200F32042 /* NSMutableAttributedString+Extension.swift */,
+				70107BA02C36661200F32042 /* NSAttributedString+Extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -620,7 +620,7 @@
 				7D1E5FBA2C0A28080012504D /* MainTabCoordinator.swift in Sources */,
 				7DD2CB872C2ED63E0052ECCD /* SettingsCoordinator.swift in Sources */,
 				7DD2CB812C2ED4430052ECCD /* FeaturedViewHolder.swift in Sources */,
-				70107BA12C36661200F32042 /* NSMutableAttributedString+Extension.swift in Sources */,
+				70107BA12C36661200F32042 /* NSAttributedString+Extension.swift in Sources */,
 				7D3E962A2C061DA3003A6FA9 /* SampleAPI.swift in Sources */,
 				7DEACE4C2C1ECC5200F37DA3 /* CustomFont.swift in Sources */,
 				7D29812F2C01F23400A619FB /* SavedViewController.swift in Sources */,

--- a/ShowPot/ShowPot.xcodeproj/project.pbxproj
+++ b/ShowPot/ShowPot.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		70107B702C216A4200F32042 /* KakaoSDKTalk in Frameworks */ = {isa = PBXBuildFile; productRef = 70107B6F2C216A4200F32042 /* KakaoSDKTalk */; };
 		70107B722C216A4200F32042 /* KakaoSDKTemplate in Frameworks */ = {isa = PBXBuildFile; productRef = 70107B712C216A4200F32042 /* KakaoSDKTemplate */; };
 		70107B742C216A4200F32042 /* KakaoSDKUser in Frameworks */ = {isa = PBXBuildFile; productRef = 70107B732C216A4200F32042 /* KakaoSDKUser */; };
+		70107B912C2E537E00F32042 /* UILabel+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70107B902C2E537E00F32042 /* UILabel+Extension.swift */; };
 		7D1092262C26F36800498C87 /* FlexLayout in Frameworks */ = {isa = PBXBuildFile; productRef = 7D1092252C26F36800498C87 /* FlexLayout */; };
 		7D1092292C26F38800498C87 /* PinLayout in Frameworks */ = {isa = PBXBuildFile; productRef = 7D1092282C26F38800498C87 /* PinLayout */; };
 		7D13C3522C35A8A30017AE93 /* MainTabController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D13C3512C35A8A30017AE93 /* MainTabController.swift */; };
@@ -107,6 +108,7 @@
 		70107B262C1D573900F32042 /* Oswald-SemiBold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Oswald-SemiBold.ttf"; sourceTree = "<group>"; };
 		70107B2F2C1D58C500F32042 /* UIFont+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+Extension.swift"; sourceTree = "<group>"; };
 		7D13C3512C35A8A30017AE93 /* MainTabController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabController.swift; sourceTree = "<group>"; };
+		70107B902C2E537E00F32042 /* UILabel+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+Extension.swift"; sourceTree = "<group>"; };
 		7D1E5FAC2C0A20950012504D /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		7D1E5FAE2C0A20A10012504D /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
 		7D1E5FB32C0A23700012504D /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
@@ -341,6 +343,7 @@
 			isa = PBXGroup;
 			children = (
 				70107B2F2C1D58C500F32042 /* UIFont+Extension.swift */,
+				70107B902C2E537E00F32042 /* UILabel+Extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -619,6 +622,7 @@
 				7D29812F2C01F23400A619FB /* SavedViewController.swift in Sources */,
 				7DD2CB832C2ED5510052ECCD /* SavedCoordinator.swift in Sources */,
 				7D8574C12C187A1F0042F539 /* LoginViewHolder.swift in Sources */,
+				70107B912C2E537E00F32042 /* UILabel+Extension.swift in Sources */,
 				7D2981002C01E1D000A619FB /* AppDelegate.swift in Sources */,
 				7D2981372C01F25B00A619FB /* APIService.swift in Sources */,
 				7D1E5FB62C0A23AB0012504D /* LoginCoordinator.swift in Sources */,

--- a/ShowPot/ShowPot.xcodeproj/project.pbxproj
+++ b/ShowPot/ShowPot.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		70107B722C216A4200F32042 /* KakaoSDKTemplate in Frameworks */ = {isa = PBXBuildFile; productRef = 70107B712C216A4200F32042 /* KakaoSDKTemplate */; };
 		70107B742C216A4200F32042 /* KakaoSDKUser in Frameworks */ = {isa = PBXBuildFile; productRef = 70107B732C216A4200F32042 /* KakaoSDKUser */; };
 		70107B912C2E537E00F32042 /* UILabel+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70107B902C2E537E00F32042 /* UILabel+Extension.swift */; };
+		70107BA12C36661200F32042 /* NSMutableAttributedString+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70107BA02C36661200F32042 /* NSMutableAttributedString+Extension.swift */; };
 		7D1092262C26F36800498C87 /* FlexLayout in Frameworks */ = {isa = PBXBuildFile; productRef = 7D1092252C26F36800498C87 /* FlexLayout */; };
 		7D1092292C26F38800498C87 /* PinLayout in Frameworks */ = {isa = PBXBuildFile; productRef = 7D1092282C26F38800498C87 /* PinLayout */; };
 		7D13C3522C35A8A30017AE93 /* MainTabController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D13C3512C35A8A30017AE93 /* MainTabController.swift */; };
@@ -109,6 +110,7 @@
 		70107B2F2C1D58C500F32042 /* UIFont+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+Extension.swift"; sourceTree = "<group>"; };
 		7D13C3512C35A8A30017AE93 /* MainTabController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabController.swift; sourceTree = "<group>"; };
 		70107B902C2E537E00F32042 /* UILabel+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+Extension.swift"; sourceTree = "<group>"; };
+		70107BA02C36661200F32042 /* NSMutableAttributedString+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSMutableAttributedString+Extension.swift"; sourceTree = "<group>"; };
 		7D1E5FAC2C0A20950012504D /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		7D1E5FAE2C0A20A10012504D /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
 		7D1E5FB32C0A23700012504D /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
@@ -344,6 +346,7 @@
 			children = (
 				70107B2F2C1D58C500F32042 /* UIFont+Extension.swift */,
 				70107B902C2E537E00F32042 /* UILabel+Extension.swift */,
+				70107BA02C36661200F32042 /* NSMutableAttributedString+Extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -617,6 +620,7 @@
 				7D1E5FBA2C0A28080012504D /* MainTabCoordinator.swift in Sources */,
 				7DD2CB872C2ED63E0052ECCD /* SettingsCoordinator.swift in Sources */,
 				7DD2CB812C2ED4430052ECCD /* FeaturedViewHolder.swift in Sources */,
+				70107BA12C36661200F32042 /* NSMutableAttributedString+Extension.swift in Sources */,
 				7D3E962A2C061DA3003A6FA9 /* SampleAPI.swift in Sources */,
 				7DEACE4C2C1ECC5200F37DA3 /* CustomFont.swift in Sources */,
 				7D29812F2C01F23400A619FB /* SavedViewController.swift in Sources */,

--- a/ShowPot/ShowPot/Common/Extension/NSAttributedString+Extension.swift
+++ b/ShowPot/ShowPot/Common/Extension/NSAttributedString+Extension.swift
@@ -7,12 +7,12 @@
 
 import UIKit
 
-extension NSMutableAttributedString {
+extension NSAttributedString {
     
     /// 줄 높이를 설정을 위한 attribute를 추가합니다.
     /// - Parameters:
     ///   - lineHeightMultiple: UILabel의 줄 높이 배수 (예: 1.5 = 150%)
-    func setLineHeight(lineHeightMultiple: CGFloat) -> Self {
+    func setLineHeight(lineHeightMultiple: CGFloat) -> NSAttributedString {
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.lineHeightMultiple = lineHeightMultiple
         
@@ -20,19 +20,21 @@ extension NSMutableAttributedString {
             .paragraphStyle: paragraphStyle
         ]
         
-        self.addAttributes(attributes, range: NSRange(location: 0, length: self.length))
-        return self
+        let mutableAttributedString = NSMutableAttributedString(attributedString: self)
+        mutableAttributedString.addAttributes(attributes, range: NSRange(location: 0, length: self.length))
+        return NSAttributedString(attributedString: mutableAttributedString)
     }
     
     /// 자간 설정을 위한 attribute를 추가합니다.
     /// - Parameters:
     ///   - letterSpacingPercent: UILabel의 자간 백분율 (예: -0.025 = -2.5%)
-    func setLetterSpacing(letterSpacingPercent: CGFloat) -> Self {
+    func setLetterSpacing(letterSpacingPercent: CGFloat) -> NSAttributedString {
         let attributes: [NSAttributedString.Key: Any] = [
             .kern: letterSpacingPercent
         ]
         
-        self.addAttributes(attributes, range: NSRange(location: 0, length: self.length))
-        return self
+        let mutableAttributedString = NSMutableAttributedString(attributedString: self)
+        mutableAttributedString.addAttributes(attributes, range: NSRange(location: 0, length: self.length))
+        return NSAttributedString(attributedString: mutableAttributedString)
     }
 }

--- a/ShowPot/ShowPot/Common/Extension/NSMutableAttributedString+Extension.swift
+++ b/ShowPot/ShowPot/Common/Extension/NSMutableAttributedString+Extension.swift
@@ -1,0 +1,38 @@
+//
+//  NSAttributedString+Extension.swift
+//  ShowPot
+//
+//  Created by 이건준 on 7/4/24.
+//
+
+import UIKit
+
+extension NSMutableAttributedString {
+    
+    /// 줄 높이를 설정을 위한 attribute를 추가합니다.
+    /// - Parameters:
+    ///   - lineHeightMultiple: UILabel의 줄 높이 배수 (예: 1.5 = 150%)
+    func setLineHeight(lineHeightMultiple: CGFloat) -> Self {
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineHeightMultiple = lineHeightMultiple
+        
+        let attributes: [NSAttributedString.Key: Any] = [
+            .paragraphStyle: paragraphStyle
+        ]
+        
+        self.addAttributes(attributes, range: NSRange(location: 0, length: self.length))
+        return self
+    }
+    
+    /// 자간 설정을 위한 attribute를 추가합니다.
+    /// - Parameters:
+    ///   - letterSpacingPercent: UILabel의 자간 백분율 (예: -0.025 = -2.5%)
+    func setLetterSpacing(letterSpacingPercent: CGFloat) -> Self {
+        let attributes: [NSAttributedString.Key: Any] = [
+            .kern: letterSpacingPercent
+        ]
+        
+        self.addAttributes(attributes, range: NSRange(location: 0, length: self.length))
+        return self
+    }
+}

--- a/ShowPot/ShowPot/Common/Extension/UILabel+Extension.swift
+++ b/ShowPot/ShowPot/Common/Extension/UILabel+Extension.swift
@@ -1,0 +1,79 @@
+//
+//  UILabel+Extension.swift
+//  ShowPot
+//
+//  Created by 이건준 on 6/28/24.
+//
+
+import UIKit
+
+extension UILabel {
+    
+    /// UILabel의 줄 높이를 설정합니다.
+    /// - Parameters:
+    ///   - lineHeightMultiple: UILabel의 줄 높이 배수 (예: 1.5 = 150%)
+    ///   - string: UILabel에 설정할 텍스트
+    func setLineHeight(lineHeightMultiple: CGFloat, string: String) {
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineHeightMultiple = lineHeightMultiple
+        
+        let attributedString = NSAttributedString(
+            string: string,
+            attributes: [
+                .paragraphStyle: paragraphStyle
+            ]
+        )
+        
+        self.attributedText = attributedString
+    }
+    
+    /// UILabel의 자간을 설정합니다.
+    /// - Parameters:
+    ///   - letterSpacingPercent: UILabel의 자간 백분율 (예: -0.025 = -2.5%)
+    ///   - string: UILabel에 설정할 텍스트
+    func setLetterSpacing(letterSpacingPercent: CGFloat, string: String) {
+        // Calculate the actual letter spacing from the percentage
+        let letterSpacing = letterSpacingPercent * UIFont.systemFont(ofSize: self.font.pointSize).pointSize
+        
+        let attributedString = NSAttributedString(
+            string: string,
+            attributes: [
+                .kern: letterSpacing
+            ]
+        )
+        
+        self.attributedText = attributedString
+    }
+    
+    /// UILabel의 줄 높이와 자간을 폰트에 따라 설정합니다.
+    func setLineHeightAndLetterSpacingForFont() {
+        guard let currentText = self.text, let fontName = self.font?.fontName.split(separator: "-")[0] else { return }
+        
+        let lineHeightMultiple: CGFloat = 1.5
+        var letterSpacing: CGFloat = 0.0
+        
+        switch fontName {
+        case CustomFont.pretendard.rawValue:
+            letterSpacing = -0.025
+        case CustomFont.oswald.rawValue:
+            letterSpacing = 0.0
+        default:
+            LogHelper.error("유효한 폰트종류가 아닙니다, 적용된 폰트이름을 확인해주세요.")
+            return
+        }
+        
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineHeightMultiple = lineHeightMultiple
+        
+        let attributedString = NSAttributedString(
+            string: currentText,
+            attributes: [
+                .paragraphStyle: paragraphStyle,
+                .kern: letterSpacing,
+                .font: self.font as Any
+            ]
+        )
+        
+        self.attributedText = attributedString
+    }
+}

--- a/ShowPot/ShowPot/Common/Extension/UILabel+Extension.swift
+++ b/ShowPot/ShowPot/Common/Extension/UILabel+Extension.swift
@@ -9,74 +9,13 @@ import UIKit
 
 extension UILabel {
     
-    /// UILabel의 줄 높이를 설정합니다.
+    /// UILabel의 자간 및 줄 높이에 대한 attributedText를 설정합니다.
     /// - Parameters:
-    ///   - lineHeightMultiple: UILabel의 줄 높이 배수 (예: 1.5 = 150%)
+    ///   - font: LanguageFont 프로토콜을 준수하는 타입
     ///   - string: UILabel에 설정할 텍스트
-    func setLineHeight(lineHeightMultiple: CGFloat, string: String) {
-        let paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.lineHeightMultiple = lineHeightMultiple
-        
-        let attributedString = NSAttributedString(
-            string: string,
-            attributes: [
-                .paragraphStyle: paragraphStyle
-            ]
-        )
-        
-        self.attributedText = attributedString
-    }
-    
-    /// UILabel의 자간을 설정합니다.
-    /// - Parameters:
-    ///   - letterSpacingPercent: UILabel의 자간 백분율 (예: -0.025 = -2.5%)
-    ///   - string: UILabel에 설정할 텍스트
-    func setLetterSpacing(letterSpacingPercent: CGFloat, string: String) {
-        // Calculate the actual letter spacing from the percentage
-        let letterSpacing = letterSpacingPercent * self.font.pointSize
-        
-        let attributedString = NSAttributedString(
-            string: string,
-            attributes: [
-                .kern: letterSpacing
-            ]
-        )
-        
-        self.attributedText = attributedString
-    }
-    
-    /// UILabel의 줄 높이와 자간을 폰트에 따라 설정합니다.
-    func setLineHeightAndLetterSpacingForFont() {
-        guard let currentText = self.text,
-              let fontName = self.font?.fontName.split(separator: "-")[0] else { return }
-        
-        var lineHeightMultiple: CGFloat = 0.0
-        var letterSpacing: CGFloat = 0.0
-        
-        switch fontName {
-        case CustomFont.pretendard.rawValue:
-            lineHeightMultiple = KRFont.lineHeight
-            letterSpacing = KRFont.letterSpacing * self.font.pointSize
-        case CustomFont.oswald.rawValue:
-            lineHeightMultiple = ENFont.lineHeight
-            letterSpacing = ENFont.letterSpacing * self.font.pointSize
-        default:
-            LogHelper.error("유효한 폰트종류가 아닙니다, 적용된 폰트이름을 확인해주세요.")
-            return
-        }
-        
-        let paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.lineHeightMultiple = lineHeightMultiple
-        
-        let attributedString = NSAttributedString(
-            string: currentText,
-            attributes: [
-                .paragraphStyle: paragraphStyle,
-                .kern: letterSpacing,
-                .font: self.font as Any
-            ]
-        )
-        
-        self.attributedText = attributedString
+    func setAttributedText<T: LanguageFont>(font: T.Type, string: String) {
+        self.attributedText = NSMutableAttributedString(string: string)
+            .setLineHeight(lineHeightMultiple: font.lineHeight)
+            .setLetterSpacing(letterSpacingPercent: font.letterSpacing)
     }
 }

--- a/ShowPot/ShowPot/Common/Extension/UILabel+Extension.swift
+++ b/ShowPot/ShowPot/Common/Extension/UILabel+Extension.swift
@@ -49,14 +49,16 @@ extension UILabel {
     func setLineHeightAndLetterSpacingForFont() {
         guard let currentText = self.text, let fontName = self.font?.fontName.split(separator: "-")[0] else { return }
         
-        let lineHeightMultiple: CGFloat = 1.5
+        var lineHeightMultiple: CGFloat = 0.0
         var letterSpacing: CGFloat = 0.0
         
         switch fontName {
         case CustomFont.pretendard.rawValue:
-            letterSpacing = -0.025
+            lineHeightMultiple = KRFont.lineHeight
+            letterSpacing = KRFont.letterSpacing
         case CustomFont.oswald.rawValue:
-            letterSpacing = 0.0
+            lineHeightMultiple = ENFont.lineHeight
+            letterSpacing = ENFont.letterSpacing
         default:
             LogHelper.error("유효한 폰트종류가 아닙니다, 적용된 폰트이름을 확인해주세요.")
             return

--- a/ShowPot/ShowPot/Common/Extension/UILabel+Extension.swift
+++ b/ShowPot/ShowPot/Common/Extension/UILabel+Extension.swift
@@ -33,7 +33,7 @@ extension UILabel {
     ///   - string: UILabel에 설정할 텍스트
     func setLetterSpacing(letterSpacingPercent: CGFloat, string: String) {
         // Calculate the actual letter spacing from the percentage
-        let letterSpacing = letterSpacingPercent * UIFont.systemFont(ofSize: self.font.pointSize).pointSize
+        let letterSpacing = letterSpacingPercent * self.font.pointSize
         
         let attributedString = NSAttributedString(
             string: string,
@@ -47,7 +47,8 @@ extension UILabel {
     
     /// UILabel의 줄 높이와 자간을 폰트에 따라 설정합니다.
     func setLineHeightAndLetterSpacingForFont() {
-        guard let currentText = self.text, let fontName = self.font?.fontName.split(separator: "-")[0] else { return }
+        guard let currentText = self.text,
+              let fontName = self.font?.fontName.split(separator: "-")[0] else { return }
         
         var lineHeightMultiple: CGFloat = 0.0
         var letterSpacing: CGFloat = 0.0
@@ -55,10 +56,10 @@ extension UILabel {
         switch fontName {
         case CustomFont.pretendard.rawValue:
             lineHeightMultiple = KRFont.lineHeight
-            letterSpacing = KRFont.letterSpacing
+            letterSpacing = KRFont.letterSpacing * self.font.pointSize
         case CustomFont.oswald.rawValue:
             lineHeightMultiple = ENFont.lineHeight
-            letterSpacing = ENFont.letterSpacing
+            letterSpacing = ENFont.letterSpacing * self.font.pointSize
         default:
             LogHelper.error("유효한 폰트종류가 아닙니다, 적용된 폰트이름을 확인해주세요.")
             return


### PR DESCRIPTION
## Describe
- KRFont, ENFont인 경우에 따른 letterSpacing, lineHeight값 조절을 위한 함수 구현
- letterSpacing, lineHeight값을 커스텀할 수 있는 함수 구현

## Works made
- 텍스트에 따라 letterSpacing, lineHeight값을 조절해야했기에 이를 위한 함수가 필요하다 생각하여 구현
- 폰트에 따라서 일일이 letterSpcing, lineHeight값을 조절할 필요없이 함수사용만 하면 간편하게 적용하기위한 함수 구현

### As-Is
<!-- 작업 이전 동작하던 부분을 기재합니다 -->
**기존 로직**
``` swift
let label = UILabel().then {
    $0.font = ENFont.H0
    let paragraphStyle = NSMutableParagraphStyle()
    paragraphStyle.lineHeightMultiple = 1.5

    let attributedString = NSAttributedString(
      string: "예시를 위한 라벨 텍스트",
      attributes: [
        .paragraphStyle: paragraphStyle
      ]
    )
    
    $0.attributedText = attributedString
}
```
- 기존에는 특정 폰트 별로 직접 letterSpacing, lineHeight값을 추가하고 attributedString을 일일이 작성해야함

### To-BE
**변경 로직**
``` swift
let krFontLabel = UILabel().then {
    $0.setAttributedText(font: KRFont.self, string: "KRFont가 적용된 예시 텍스트입니다.")
}

let enFontLabel = UILabel().then {
    $0.setAttributedText(font: ENFont.self, string: "ENFont가 적용된 예시 텍스트입니다.")
}
```
- 간단한 함수작성으로 폰트 종류를 판별하여 함수내부에서 letterSpacing, lineHeight값 조절해줍니다.
- LanguageFont에 맞춰 내부적으로 letterSpacing, lineHeight값을 조절합니다.
- ~~**반드시 예시 코드와 같이 `폰트와 텍스트 작성이후 함수를 실행`해야 올바르게 폰트에 따른 letterSpacing, lineHeight값을 조절하실 수 있습니다.**~~

|KRFont 적용하기 이전 스크린샷|KRFont 적용하기 이후 스크린샷|
|:--:|:-:|
|<img src="https://github.com/YAPP-Github/24th-App-Team-3-iOS/assets/39263235/d28db240-4e67-43b2-b5a8-61638a24159d" width="300" height="600">|<img src="https://github.com/YAPP-Github/24th-App-Team-3-iOS/assets/39263235/bc002ba3-d472-4b0d-8a86-b2a3de43ff55" width="300" height="600">

#### <적용전 코드>
``` swift
let label = UILabel().then {
            $0.textColor = .black
            $0.numberOfLines = .max
            $0.text = """
                        테스트용 라벨입니다.
                        속성값 적용하지않은 텍스트입니다.
            """
}
```

#### <적용후 코드>
``` swift
let label = UILabel().then {
            $0.textColor = .black
            $0.numberOfLines = .max
            $0.setAttributedText(font: KRFont.self, string:
                    """
                        테스트용 라벨입니다.
                        속성값 적용한 텍스트입니다.
                    """
            )
}
```

|ENFont 적용하기 이전 스크린샷|ENFont 적용하기 이후 스크린샷|
|:--:|:-:|
|<img src="https://github.com/YAPP-Github/24th-App-Team-3-iOS/assets/39263235/dc39561a-d333-47da-af43-7204e4ede08d" width="300" height="600">|<img src="https://github.com/YAPP-Github/24th-App-Team-3-iOS/assets/39263235/5ed78ff4-212e-407e-9b4a-393ba60a1319" width="300" height="600">

#### <적용전 코드>
``` swift
let label = UILabel().then {
            $0.textColor = .black
            $0.numberOfLines = .max
            $0.text = """
                        Hello, This is test.
                        Text that does not apply attribute values.
            """
}
```

#### <적용후 코드>
``` swift
let label = UILabel().then {
            $0.textColor = .black
            $0.numberOfLines = .max
            $0.setAttributedText(font: ENFont.self, string:
                    """
                        Hello, This is test.
                        Text that does apply attribute values.
                    """
            )
}
```

## How to Test
- 위 변경된 코드처럼 ~~폰트 적용 이후~~ `setAttributedText` 함수를 사용하여 변경된 모습을 확인합니다.

## Issues Resolved
- #37 
## Additional context
- 반드시 예시 코드와 같이 폰트와 텍스트 작성이후 함수를 실행해야 올바르게 폰트에 따른 letterSpacing, lineHeight값을 조절하실 수 있습니다.

## References
[letterSpacing 자간율 적용 참고](https://ggasoon2.tistory.com/28)