### PR TITLE
[Fix] #39 잘못된 ENFont정보 수정

### DIFF
--- a/ShowPot/ShowPot/Common/Font/ENFont.swift
+++ b/ShowPot/ShowPot/Common/Font/ENFont.swift
@@ -14,10 +14,10 @@ enum ENFont: LanguageFont {
     static var letterSpacing: CGFloat = 0.0
     
     // 디자인 시스템에 명시된 폰트
-    static let H0: UIFont = .customFont(font: font, style: .semiBold, size: 30)
-    static let H1: UIFont = .customFont(font: font, style: .semiBold, size: 24)
-    static let H2: UIFont = .customFont(font: font, style: .semiBold, size: 22)
-    static let H3: UIFont = .customFont(font: font, style: .semiBold, size: 20)
-    static let H4: UIFont = .customFont(font: font, style: .semiBold, size: 28)
-    static let H5: UIFont = .customFont(font: font, style: .semiBold, size: 16)
+    static let H0: UIFont = .customFont(font: font, style: .regular, size: 30)
+    static let H1: UIFont = .customFont(font: font, style: .regular, size: 24)
+    static let H2: UIFont = .customFont(font: font, style: .regular, size: 22)
+    static let H3: UIFont = .customFont(font: font, style: .regular, size: 20)
+    static let H4: UIFont = .customFont(font: font, style: .regular, size: 18)
+    static let H5: UIFont = .customFont(font: font, style: .regular, size: 16)
 }


### PR DESCRIPTION
## Describe
- ENFont의 해당하는 폰트들의 잘못된 정보를 수정

## Works made
- ENFont의 style을 `semibold`에서 `regular`로 수정
- ENFont의 H4폰트의 사이즈를 `28`에서 `18`로 수정

## How to Test
- ENFont의 해당하는 라벨 텍스트를 통해 확인

## Issues Resolved
- #39 

## References
[프로젝트 Typo에 해당하는 피그마 페이지 링크](https://www.figma.com/design/DRATa4JWezKKCsUcWymd09/%EB%94%94%EC%9E%90%EC%9D%B8%EC%8B%9C%EC%8A%A4%ED%85%9C?node-id=1-2)