### PR TITLE
[Feature] #37 letterSpacing, lineHeight값 적용을 위한 Extension 오류 수정

### DIFF
--- a/ShowPot/ShowPot/Common/Extension/NSAttributedString+Extension.swift
+++ b/ShowPot/ShowPot/Common/Extension/NSAttributedString+Extension.swift
@@ -37,4 +37,14 @@ extension NSAttributedString {
         mutableAttributedString.addAttributes(attributes, range: NSRange(location: 0, length: self.length))
         return NSAttributedString(attributedString: mutableAttributedString)
     }
+    
+    func setBaseLineOffset(baselineOffset: CGFloat) -> NSAttributedString {
+        let attributes: [NSAttributedString.Key: Any] = [
+            .baselineOffset: baselineOffset
+        ]
+        
+        let mutableAttributedString = NSMutableAttributedString(attributedString: self)
+        mutableAttributedString.addAttributes(attributes, range: NSRange(location: 0, length: self.length))
+        return NSAttributedString(attributedString: mutableAttributedString)
+    }
 }

--- a/ShowPot/ShowPot/Common/Extension/NSAttributedString+Extension.swift
+++ b/ShowPot/ShowPot/Common/Extension/NSAttributedString+Extension.swift
@@ -11,10 +11,11 @@ extension NSAttributedString {
     
     /// 줄 높이를 설정을 위한 attribute를 추가합니다.
     /// - Parameters:
-    ///   - lineHeightMultiple: UILabel의 줄 높이 배수 (예: 1.5 = 150%)
-    func setLineHeight(lineHeightMultiple: CGFloat) -> NSAttributedString {
+    ///   - lineHeight: UILabel의 줄 높이
+    func setLineHeight(lineHeight: CGFloat) -> NSAttributedString {
         let paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.lineHeightMultiple = lineHeightMultiple
+        paragraphStyle.maximumLineHeight = lineHeight
+        paragraphStyle.minimumLineHeight = lineHeight
         
         let attributes: [NSAttributedString.Key: Any] = [
             .paragraphStyle: paragraphStyle

--- a/ShowPot/ShowPot/Common/Extension/UILabel+Extension.swift
+++ b/ShowPot/ShowPot/Common/Extension/UILabel+Extension.swift
@@ -14,10 +14,12 @@ extension UILabel {
     ///   - font: LanguageFont 프로토콜을 준수하는 타입
     ///   - string: UILabel에 설정할 텍스트
     func setAttributedText<T: LanguageFont>(font: T.Type, string: String) {
+        
+        let lineHeight = self.font.lineHeight * font.lineHeightMultiple
+        
         self.attributedText = NSMutableAttributedString(string: string)
-            .setLineHeight(lineHeightMultiple: font.lineHeight)
-            .setLineHeight(lineHeightMultiple: font.lineHeightMultiple)
+            .setLineHeight(lineHeight: lineHeight)
             .setLetterSpacing(letterSpacingPercent: font.letterSpacing)
-            .setBaseLineOffset(baselineOffset: (font.lineHeight - self.font.lineHeight) / 4)
+            .setBaseLineOffset(baselineOffset: (lineHeight - self.font.lineHeight) / 2)
     }
 }

--- a/ShowPot/ShowPot/Common/Extension/UILabel+Extension.swift
+++ b/ShowPot/ShowPot/Common/Extension/UILabel+Extension.swift
@@ -16,6 +16,7 @@ extension UILabel {
     func setAttributedText<T: LanguageFont>(font: T.Type, string: String) {
         self.attributedText = NSMutableAttributedString(string: string)
             .setLineHeight(lineHeightMultiple: font.lineHeight)
+            .setLineHeight(lineHeightMultiple: font.lineHeightMultiple)
             .setLetterSpacing(letterSpacingPercent: font.letterSpacing)
             .setBaseLineOffset(baselineOffset: (font.lineHeight - self.font.lineHeight) / 4)
     }

--- a/ShowPot/ShowPot/Common/Extension/UILabel+Extension.swift
+++ b/ShowPot/ShowPot/Common/Extension/UILabel+Extension.swift
@@ -17,5 +17,6 @@ extension UILabel {
         self.attributedText = NSMutableAttributedString(string: string)
             .setLineHeight(lineHeightMultiple: font.lineHeight)
             .setLetterSpacing(letterSpacingPercent: font.letterSpacing)
+            .setBaseLineOffset(baselineOffset: (font.lineHeight - self.font.lineHeight) / 4)
     }
 }

--- a/ShowPot/ShowPot/Common/Font/ENFont.swift
+++ b/ShowPot/ShowPot/Common/Font/ENFont.swift
@@ -10,7 +10,7 @@ import UIKit
 /// 영어 폰트 스타일
 enum ENFont: LanguageFont {
     static var font: CustomFont = .oswald
-    static var lineHeight: CGFloat = 1.5
+    static var lineHeightMultiple: CGFloat = 1.5
     static var letterSpacing: CGFloat = 0.0
     
     // 디자인 시스템에 명시된 폰트

--- a/ShowPot/ShowPot/Common/Font/KRFont.swift
+++ b/ShowPot/ShowPot/Common/Font/KRFont.swift
@@ -10,7 +10,7 @@ import UIKit
 /// 한국어 폰트 스타일
 enum KRFont: LanguageFont {
     static var font: CustomFont = .pretendard
-    static var lineHeight: CGFloat = 1.5
+    static var lineHeightMultiple: CGFloat = 1.5
     static var letterSpacing: CGFloat = -0.025
     
     // 디자인 시스템에 명시된 폰트

--- a/ShowPot/ShowPot/Common/Font/LanguageFont.swift
+++ b/ShowPot/ShowPot/Common/Font/LanguageFont.swift
@@ -14,8 +14,8 @@ protocol LanguageFont {
     /// 폰트 이름
     static var font: CustomFont { get }
     
-    /// AttributedString에 사용할 lineHeight
-    static var lineHeight: CGFloat { get }
+    /// AttributedString에 사용할 lineHeight 배율
+    static var lineHeightMultiple: CGFloat { get }
     
     /// AttributedString에 사용할 letterSpacing
     static var letterSpacing: CGFloat { get }


### PR DESCRIPTION
<!--- 
Pull Request 제목은 반드시 아래의 형식을 따라야 합니다.
[<Category>] <issue number> <description> (e.g. "[Feature] #123 새로운 제스쳐 추가") 
-->

## Describe
이전 #38  PR에서 작업한 코드를 이용할 경우, `lineHeight` 설정시 두가지 이슈 발생
1. 텍스트가 중앙 정렬되지 않고, line의 바닥에 붙어서 표출
2. 실제 의도한 `lineHeight`의 배율과 다른 크기로 `lineHeight` 표출

## Works made
- 1.5와 같은 배율값이지만 `lineHeight`로 네이밍되어 있어 `lineHeightMultiple`로 네이밍 수정
- `lineHeightMultiple`값을 이용해, 직업 `lineHeight` 설정하는 방식으로 수정

## Changes Made
<!--- 변경된 부분을 asis-tobe 형식으로 작성합니다. UI 변경이 있을 경우 반드시 모든 부분의 스크린샷을 첨부해야 하며 비즈니스 로직이 바뀌었다면 따로 적어줍니다. -->

### As-Is
<!-- 작업 이전 동작하던 부분을 기재합니다 -->
**기존 로직**
- 폰트별 lineHeight의 배율값을 `LanugaeFont.lineHeight = 1.5` 방식으로 저장
- `NSMutableParagraphStyle. lineHeightMultiple` 사용
```swift
    func setLineHeight(lineHeightMultiple: CGFloat) -> NSAttributedString {
        let paragraphStyle = NSMutableParagraphStyle()
        paragraphStyle.lineHeightMultiple = lineHeightMultiple ❌ 

        
        let attributes: [NSAttributedString.Key: Any] = [
            .paragraphStyle: paragraphStyle
        ]
        
        let mutableAttributedString = NSMutableAttributedString(attributedString: self)
        mutableAttributedString.addAttributes(attributes, range: NSRange(location: 0, length: self.length))
        return NSAttributedString(attributedString: mutableAttributedString)
    }
```
```swift
   func setAttributedText<T: LanguageFont>(font: T.Type, string: String) {

        self.attributedText = NSMutableAttributedString(string: string) 
            .setLineHeight(lineHeightMultiple: font.lineHeightMultiple) ❌                                     
            .setLetterSpacing(letterSpacingPercent: font.letterSpacing)
            .setBaseLineOffset(baselineOffset: (font.lineHeight - self.font.lineHeight) / 4) ❌
    }
```

**스크린샷**
<img src="https://github.com/YAPP-Github/24th-App-Team-3-iOS/assets/43776784/525b5651-03c6-4233-8e7d-8e5f05681e08" width="25%" alt="lineHeight 잘못 적용 예시">

> 실제로 1.5배의 lineHeight를 가지는지 테스트하기 위해 lineHeight 적용 안된 label 두개를 세로 배열하고, 위쪽 label의 중앙에 line 배치
lineHeight 배율을 1.5배 적용한 Label이 line보다 높게 존재 -> 1.5 배 보다 더 큰 lineHeight를 가짐

### To-BE
<!-- 작업 이후 변경된 부분을 기재합니다. -->
**변경 로직**
- 폰트별 lineHeight의 배율값을 `LanugaeFont.lineHeightMultiple = 1.5` 방식으로 **네이밍 수정**
- `NSMutableParagraphStyle. lineHeight` 사용
```swift
    func setLineHeight(lineHeight: CGFloat) -> NSAttributedString {
        let paragraphStyle = NSMutableParagraphStyle()
        paragraphStyle.maximumLineHeight = lineHeight ✅
        paragraphStyle.minimumLineHeight = lineHeight ✅
        
        let attributes: [NSAttributedString.Key: Any] = [
            .paragraphStyle: paragraphStyle
        ]
        
        let mutableAttributedString = NSMutableAttributedString(attributedString: self)
        mutableAttributedString.addAttributes(attributes, range: NSRange(location: 0, length: self.length))
        return NSAttributedString(attributedString: mutableAttributedString)
    }
```
```swift
    func setAttributedText<T: LanguageFont>(font: T.Type, string: String) {
        
        let lineHeight = self.font.lineHeight * font.lineHeightMultiple
        
        self.attributedText = NSMutableAttributedString(string: string)
            .setLineHeight(lineHeight: lineHeight) ✅
            .setLetterSpacing(letterSpacingPercent: font.letterSpacing)
            .setBaseLineOffset(baselineOffset: (lineHeight - self.font.lineHeight) / 2) ✅
    }
```
**스크린샷**
<img src="https://github.com/YAPP-Github/24th-App-Team-3-iOS/assets/43776784/91858a15-d95d-472d-ac8f-72f78aa03896" width="25%" alt="lineheight 수정 완료">

> 위쪽 초록선: lineHeight 1.5배 여부 테스트 / 아래쪽 초록선: 텍스트 중앙정렬 테스트
테스트용 초록선 두개 다 적합하게 표출됨

## How to Test
`FeaturedViewHolder`에 해당 코드를 넣어 테스트
```swift
final class FeaturedViewHolder {
    
    let line = UIView().then { view in
        view.backgroundColor = .green
    }
    
    let line2 = UIView().then { view in
        view.backgroundColor = .green
    }
    
    let label = UILabel().then { label in
        label.backgroundColor = .red
        label.text = "EEEEEE"
        label.font = ENFont.H0
    }
    
    let label2 = UILabel().then { label in
        label.backgroundColor = .blue
        label.text = "EEEEEE"
        label.font = ENFont.H0
    }
    
    let attributedLabel = UILabel().then { label in
        label.backgroundColor = .red
        label.font = ENFont.H0
        label.setAttributedText(font: ENFont.self, string: "EEEEEE")
    }
    
    let stackView = UIStackView().then { stackView in
        stackView.axis = .horizontal
        stackView.spacing = 1
        stackView.alignment = .bottom
    }
}

extension FeaturedViewHolder: ViewHolderType {
    
    func place(in view: UIView) {
        view.backgroundColor = .white
        
        view.addSubview(stackView)
        view.addSubview(label2)
        view.addSubview(line)
        view.addSubview(line2)
        [label, attributedLabel].forEach { stackView.addArrangedSubview($0) }
    }
    
    func configureConstraints(for view: UIView) {
        stackView.snp.makeConstraints { make in
            make.center.equalToSuperview()
        }
        
        label2.snp.makeConstraints { make in
            make.centerX.equalTo(label.snp.centerX)
            make.bottom.equalTo(label.snp.top)
        }
        
        line.snp.makeConstraints { make in
            make.height.equalTo(1)
            make.horizontalEdges.equalToSuperview()
            make.centerY.equalTo(label2.snp.centerY)
        }
        
        line2.snp.makeConstraints { make in
            make.height.equalTo(1)
            make.horizontalEdges.equalToSuperview()
            make.centerY.equalTo(attributedLabel.snp.centerY)
        }
    }
    
}
```

## Issues Resolved
- #37 
<!-- 
연관된 이슈나 다른 PR이 있다면 적어줍니다. '#123' 처럼 이슈 번호만 적지 말고, 이슈 타이틀이 같이 보일 수 있도록 bulletin list로 작성합니다.
e.g.
 - #123
 - #124
-->

## References
- [[Swift] label의 Line Height 설정 및 가운데 정렬](https://sujinnaljin.medium.com/swift-label의-line-height-설정-및-가운데-정렬-962f7c6e7512)
- [lineHeightMultiple](https://developer.apple.com/documentation/uikit/nsmutableparagraphstyle/1524596-lineheightmultiple)
