### PR TITLE
[Feature] #37 소셜로그인 화면 자간 및 줄높이 적용

### DIFF
--- a/ShowPot/ShowPot/Presentation/Scene/Login/CustomView/SocialLoginButton.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Login/CustomView/SocialLoginButton.swift
@@ -27,7 +27,7 @@ final class SocialLoginButton: UIButton {
     
     private func setupStyles() {
         var configuration = setButtonConfiguration(with: type)
-        var attributedTitle = setButtonAttributedString(with: type)
+        let attributedTitle = setButtonAttributedString(with: type)
         configuration.attributedTitle = attributedTitle
         self.configuration = configuration
     }
@@ -60,19 +60,23 @@ extension SocialLoginButton {
         return configuration
     }
     
-    private func setButtonAttributedString(with type: SocialLoginType) -> AttributedString {
-        var attributedTitle: AttributedString
+    private func setButtonAttributedString(with type: SocialLoginType) -> AttributedString? {
+        let buttonTitleLabel = UILabel()
         
         switch type {
         case .google:
-            attributedTitle = AttributedString(Strings.socialLoginGoogleButton) // TODO: #37 lineHeight + letterSpacing 적용
+            buttonTitleLabel.setAttributedText(font: KRFont.self, string: Strings.socialLoginGoogleButton)
         case .kakao:
-            attributedTitle = AttributedString(Strings.socialLoginKakaoButton) // TODO: #37 lineHeight + letterSpacing 적용
+            buttonTitleLabel.setAttributedText(font: KRFont.self, string: Strings.socialLoginKakaoButton)
         case .apple:
-            attributedTitle = AttributedString(Strings.socialLoginAppleButton) // TODO: #37 lineHeight + letterSpacing 적용
+            buttonTitleLabel.setAttributedText(font: KRFont.self, string: Strings.socialLoginAppleButton)
         }
         
-        attributedTitle.font = KRFont.H2 // TODO: #37 lineHeight + letterSpacing 적용
-        return attributedTitle
+        if let attributedText = buttonTitleLabel.attributedText {
+            var attributedString = AttributedString(attributedText)
+            attributedString.font = KRFont.H2
+            return attributedString
+        }
+        return nil
     }
 }

--- a/ShowPot/ShowPot/Presentation/Scene/Login/CustomView/SocialLoginButton.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Login/CustomView/SocialLoginButton.swift
@@ -38,6 +38,7 @@ final class SocialLoginButton: UIButton {
 extension SocialLoginButton {
     private func setButtonConfiguration(with type: SocialLoginType) -> UIButton.Configuration {
         var configuration = UIButton.Configuration.filled()
+        configuration.cornerStyle = .fixed
         configuration.background.cornerRadius = 2
         configuration.imagePadding = 12
         

--- a/ShowPot/ShowPot/Presentation/Scene/Login/LoginViewHolder.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Login/LoginViewHolder.swift
@@ -22,9 +22,9 @@ final class LoginViewHolder {
     }
     
     let alertLabel = UILabel().then {
-        $0.text = Strings.socialLoginDescription
         $0.textColor = .white
-        $0.font = KRFont.H2 // TODO: #37 lineHeight + letterSpacing 적용
+        $0.font = KRFont.H2
+        $0.setAttributedText(font: KRFont.self, string: Strings.socialLoginDescription)
         $0.textAlignment = .center
     }
     


### PR DESCRIPTION
## Describe
- #54 자간 및 줄높이 코드 오류 수정에 따른 소셜로그인 화면에 존재하는 라벨에 적용

## Works made
- `setAttributedText`를 이용해 소셜로그인화면에 라벨에 자간 및 줄높이를 적용
- 적용 이후 올바르게 텍스트가 보이는지 확인
- 소셜로그인버튼 cornerStyle 추가

## How to Test
``` swift
let navigationController = UINavigationController()
let coordinator = LoginCoordinator(navigationController: navigationController)
window.rootViewController = navigationController
coordinator.start()
```
- SceneDelegate에 위 코드를 삽입 이후 소셜로그인 화면에 보여지는 텍스트를 확인합니다.

## Issues Resolved
- #54 