### PR TITLE
[Feature] #67 검색화면 구현 및 로직 작성

### DIFF
--- a/ShowPot/ShowPot.xcodeproj/project.pbxproj
+++ b/ShowPot/ShowPot.xcodeproj/project.pbxproj
@@ -55,6 +55,8 @@
 		7014678D2C53C12400750A54 /* FeaturedRecentSearchHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7014678C2C53C12400750A54 /* FeaturedRecentSearchHeaderView.swift */; };
 		7014678F2C53C13500750A54 /* FeaturedRecentSearchCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7014678E2C53C13500750A54 /* FeaturedRecentSearchCell.swift */; };
 		701467912C53C14600750A54 /* PerformanceInfoCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 701467902C53C14600750A54 /* PerformanceInfoCollectionViewCell.swift */; };
+		701467932C53C15800750A54 /* FeaturedSearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 701467922C53C15800750A54 /* FeaturedSearchViewController.swift */; };
+		701467952C53C16900750A54 /* FeaturedSearchViewHolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 701467942C53C16900750A54 /* FeaturedSearchViewHolder.swift */; };
 		7D1092262C26F36800498C87 /* FlexLayout in Frameworks */ = {isa = PBXBuildFile; productRef = 7D1092252C26F36800498C87 /* FlexLayout */; };
 		7D1092292C26F38800498C87 /* PinLayout in Frameworks */ = {isa = PBXBuildFile; productRef = 7D1092282C26F38800498C87 /* PinLayout */; };
 		7D13C3522C35A8A30017AE93 /* MainTabController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D13C3512C35A8A30017AE93 /* MainTabController.swift */; };
@@ -152,6 +154,8 @@
 		7014678C2C53C12400750A54 /* FeaturedRecentSearchHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturedRecentSearchHeaderView.swift; sourceTree = "<group>"; };
 		7014678E2C53C13500750A54 /* FeaturedRecentSearchCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturedRecentSearchCell.swift; sourceTree = "<group>"; };
 		701467902C53C14600750A54 /* PerformanceInfoCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceInfoCollectionViewCell.swift; sourceTree = "<group>"; };
+		701467922C53C15800750A54 /* FeaturedSearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturedSearchViewController.swift; sourceTree = "<group>"; };
+		701467942C53C16900750A54 /* FeaturedSearchViewHolder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturedSearchViewHolder.swift; sourceTree = "<group>"; };
 		7D13C3512C35A8A30017AE93 /* MainTabController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabController.swift; sourceTree = "<group>"; };
 		7D1E5FAC2C0A20950012504D /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		7D1E5FAE2C0A20A10012504D /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
@@ -315,6 +319,16 @@
 				701467862C53C0E600750A54 /* LeftAlignedCollectionViewFlowLayout.swift */,
 			);
 			path = Layout;
+			sourceTree = "<group>";
+		};
+		701467882C53C0FC00750A54 /* Search */ = {
+			isa = PBXGroup;
+			children = (
+				701467892C53C10600750A54 /* CustomView */,
+				701467922C53C15800750A54 /* FeaturedSearchViewController.swift */,
+				701467942C53C16900750A54 /* FeaturedSearchViewHolder.swift */,
+			);
+			path = Search;
 			sourceTree = "<group>";
 		};
 		701467892C53C10600750A54 /* CustomView */ = {

--- a/ShowPot/ShowPot.xcodeproj/project.pbxproj
+++ b/ShowPot/ShowPot.xcodeproj/project.pbxproj
@@ -50,7 +50,6 @@
 		701467802C53645900750A54 /* FeaturedWatchTheFullPerformanceFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7014677F2C53645900750A54 /* FeaturedWatchTheFullPerformanceFooterView.swift */; };
 		701467822C5364DE00750A54 /* FeaturedOnlyTitleHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 701467812C5364DE00750A54 /* FeaturedOnlyTitleHeaderView.swift */; };
 		70B81D602C58D9CB00665EDD /* UIView+CALayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70B81D5F2C58D9CB00665EDD /* UIView+CALayer.swift */; };
-		701467872C53C0E600750A54 /* LeftAlignedCollectionViewFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 701467862C53C0E600750A54 /* LeftAlignedCollectionViewFlowLayout.swift */; };
 		7014678B2C53C11200750A54 /* FeaturedSearchTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7014678A2C53C11200750A54 /* FeaturedSearchTextField.swift */; };
 		7014678D2C53C12400750A54 /* FeaturedRecentSearchHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7014678C2C53C12400750A54 /* FeaturedRecentSearchHeaderView.swift */; };
 		7014678F2C53C13500750A54 /* FeaturedRecentSearchCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7014678E2C53C13500750A54 /* FeaturedRecentSearchCell.swift */; };
@@ -59,6 +58,7 @@
 		701467952C53C16900750A54 /* FeaturedSearchViewHolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 701467942C53C16900750A54 /* FeaturedSearchViewHolder.swift */; };
 		701467972C53C17B00750A54 /* FeaturedSearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 701467962C53C17B00750A54 /* FeaturedSearchViewModel.swift */; };
 		701467992C53C18C00750A54 /* FeaturedSearchCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 701467982C53C18C00750A54 /* FeaturedSearchCoordinator.swift */; };
+		70B81D5E2C580E8F00665EDD /* LeftAlignedCollectionViewFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70B81D5D2C580E8F00665EDD /* LeftAlignedCollectionViewFlowLayout.swift */; };
 		7D1092262C26F36800498C87 /* FlexLayout in Frameworks */ = {isa = PBXBuildFile; productRef = 7D1092252C26F36800498C87 /* FlexLayout */; };
 		7D1092292C26F38800498C87 /* PinLayout in Frameworks */ = {isa = PBXBuildFile; productRef = 7D1092282C26F38800498C87 /* PinLayout */; };
 		7D13C3522C35A8A30017AE93 /* MainTabController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D13C3512C35A8A30017AE93 /* MainTabController.swift */; };
@@ -160,6 +160,7 @@
 		701467942C53C16900750A54 /* FeaturedSearchViewHolder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturedSearchViewHolder.swift; sourceTree = "<group>"; };
 		701467962C53C17B00750A54 /* FeaturedSearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturedSearchViewModel.swift; sourceTree = "<group>"; };
 		701467982C53C18C00750A54 /* FeaturedSearchCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturedSearchCoordinator.swift; sourceTree = "<group>"; };
+		70B81D5D2C580E8F00665EDD /* LeftAlignedCollectionViewFlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeftAlignedCollectionViewFlowLayout.swift; sourceTree = "<group>"; };
 		7D13C3512C35A8A30017AE93 /* MainTabController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabController.swift; sourceTree = "<group>"; };
 		7D1E5FAC2C0A20950012504D /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		7D1E5FAE2C0A20A10012504D /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
@@ -317,14 +318,6 @@
 			path = CustomView;
 			sourceTree = "<group>";
 		};
-		701467852C53C0DA00750A54 /* Layout */ = {
-			isa = PBXGroup;
-			children = (
-				701467862C53C0E600750A54 /* LeftAlignedCollectionViewFlowLayout.swift */,
-			);
-			path = Layout;
-			sourceTree = "<group>";
-		};
 		701467882C53C0FC00750A54 /* Search */ = {
 			isa = PBXGroup;
 			children = (
@@ -346,6 +339,22 @@
 				701467902C53C14600750A54 /* PerformanceInfoCollectionViewCell.swift */,
 			);
 			path = CustomView;
+			sourceTree = "<group>";
+		};
+		70B81D5C2C580D6100665EDD /* Recovered References */ = {
+			isa = PBXGroup;
+			children = (
+				701467862C53C0E600750A54 /* LeftAlignedCollectionViewFlowLayout.swift */,
+			);
+			name = "Recovered References";
+			sourceTree = "<group>";
+		};
+		70B81D612C59404900665EDD /* Layout */ = {
+			isa = PBXGroup;
+			children = (
+				70B81D5D2C580E8F00665EDD /* LeftAlignedCollectionViewFlowLayout.swift */,
+			);
+			path = Layout;
 			sourceTree = "<group>";
 		};
 		7D1E5FB22C0A20BB0012504D /* Login */ = {
@@ -379,6 +388,7 @@
 				7D8255A42C295DF100D104BE /* swiftgen.yml */,
 				7D2980FE2C01E1D000A619FB /* ShowPot */,
 				7D2980FD2C01E1D000A619FB /* Products */,
+				70B81D5C2C580D6100665EDD /* Recovered References */,
 			);
 			sourceTree = "<group>";
 		};
@@ -459,6 +469,7 @@
 		7D2981182C01E90A00A619FB /* UI */ = {
 			isa = PBXGroup;
 			children = (
+				70B81D612C59404900665EDD /* Layout */,
 				7DF7118A2C4810B3001406F0 /* Protocol */,
 				7DE569F22C556996006724EF /* Base */,
 				7D93096B2C569DFB000889DE /* SPSnackBar.swift */,
@@ -868,12 +879,12 @@
 				7014673D2C3F0A3400750A54 /* FeaturedSearchButton.swift in Sources */,
 				7DEACE532C1ED96400F37DA3 /* ENFont.swift in Sources */,
 				701467802C53645900750A54 /* FeaturedWatchTheFullPerformanceFooterView.swift in Sources */,
+				70B81D5E2C580E8F00665EDD /* LeftAlignedCollectionViewFlowLayout.swift in Sources */,
 				7D2981022C01E1D000A619FB /* SceneDelegate.swift in Sources */,
 				7D3196422C133EC90015F88E /* Environment.swift in Sources */,
 				701467972C53C17B00750A54 /* FeaturedSearchViewModel.swift in Sources */,
 				7014673B2C3EFC9300750A54 /* FeaturedSubscribeGenreCell.swift in Sources */,
 				7D13C3522C35A8A30017AE93 /* MainTabController.swift in Sources */,
-				701467872C53C0E600750A54 /* LeftAlignedCollectionViewFlowLayout.swift in Sources */,
 				7DD2CB892C2ED6550052ECCD /* SettingsViewHolder.swift in Sources */,
 				701467392C3EFC8500750A54 /* FeaturedWithButtonHeaderView.swift in Sources */,
 				7DE569F42C5569DF006724EF /* SnackBar.swift in Sources */,
@@ -887,7 +898,6 @@
 				7D75B91D2C4FE9F500C72417 /* UserDefaultsManager.swift in Sources */,
 				701467912C53C14600750A54 /* PerformanceInfoCollectionViewCell.swift in Sources */,
 				7D2981312C01F23C00A619FB /* SavedViewModel.swift in Sources */,
-				7D2981412C01F29D00A619FB /* SampleUI.swift in Sources */,
 				701467952C53C16900750A54 /* FeaturedSearchViewHolder.swift in Sources */,
 				7D21953F2C143AAA00A38D2B /* ViewModelType.swift in Sources */,
 				7D2195412C143E8400A38D2B /* ViewHolderType.swift in Sources */,

--- a/ShowPot/ShowPot.xcodeproj/project.pbxproj
+++ b/ShowPot/ShowPot.xcodeproj/project.pbxproj
@@ -50,6 +50,11 @@
 		701467802C53645900750A54 /* FeaturedWatchTheFullPerformanceFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7014677F2C53645900750A54 /* FeaturedWatchTheFullPerformanceFooterView.swift */; };
 		701467822C5364DE00750A54 /* FeaturedOnlyTitleHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 701467812C5364DE00750A54 /* FeaturedOnlyTitleHeaderView.swift */; };
 		70B81D602C58D9CB00665EDD /* UIView+CALayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70B81D5F2C58D9CB00665EDD /* UIView+CALayer.swift */; };
+		701467872C53C0E600750A54 /* LeftAlignedCollectionViewFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 701467862C53C0E600750A54 /* LeftAlignedCollectionViewFlowLayout.swift */; };
+		7014678B2C53C11200750A54 /* FeaturedSearchTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7014678A2C53C11200750A54 /* FeaturedSearchTextField.swift */; };
+		7014678D2C53C12400750A54 /* FeaturedRecentSearchHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7014678C2C53C12400750A54 /* FeaturedRecentSearchHeaderView.swift */; };
+		7014678F2C53C13500750A54 /* FeaturedRecentSearchCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7014678E2C53C13500750A54 /* FeaturedRecentSearchCell.swift */; };
+		701467912C53C14600750A54 /* PerformanceInfoCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 701467902C53C14600750A54 /* PerformanceInfoCollectionViewCell.swift */; };
 		7D1092262C26F36800498C87 /* FlexLayout in Frameworks */ = {isa = PBXBuildFile; productRef = 7D1092252C26F36800498C87 /* FlexLayout */; };
 		7D1092292C26F38800498C87 /* PinLayout in Frameworks */ = {isa = PBXBuildFile; productRef = 7D1092282C26F38800498C87 /* PinLayout */; };
 		7D13C3522C35A8A30017AE93 /* MainTabController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D13C3512C35A8A30017AE93 /* MainTabController.swift */; };
@@ -142,6 +147,11 @@
 		7014677F2C53645900750A54 /* FeaturedWatchTheFullPerformanceFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturedWatchTheFullPerformanceFooterView.swift; sourceTree = "<group>"; };
 		701467812C5364DE00750A54 /* FeaturedOnlyTitleHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturedOnlyTitleHeaderView.swift; sourceTree = "<group>"; };
 		70B81D5F2C58D9CB00665EDD /* UIView+CALayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+CALayer.swift"; sourceTree = "<group>"; };
+		701467862C53C0E600750A54 /* LeftAlignedCollectionViewFlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeftAlignedCollectionViewFlowLayout.swift; sourceTree = "<group>"; };
+		7014678A2C53C11200750A54 /* FeaturedSearchTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturedSearchTextField.swift; sourceTree = "<group>"; };
+		7014678C2C53C12400750A54 /* FeaturedRecentSearchHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturedRecentSearchHeaderView.swift; sourceTree = "<group>"; };
+		7014678E2C53C13500750A54 /* FeaturedRecentSearchCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturedRecentSearchCell.swift; sourceTree = "<group>"; };
+		701467902C53C14600750A54 /* PerformanceInfoCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceInfoCollectionViewCell.swift; sourceTree = "<group>"; };
 		7D13C3512C35A8A30017AE93 /* MainTabController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabController.swift; sourceTree = "<group>"; };
 		7D1E5FAC2C0A20950012504D /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		7D1E5FAE2C0A20A10012504D /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
@@ -295,6 +305,25 @@
 				7014677D2C5363FB00750A54 /* FeaturedRecommendedPerformanceCell.swift */,
 				7014677F2C53645900750A54 /* FeaturedWatchTheFullPerformanceFooterView.swift */,
 				701467812C5364DE00750A54 /* FeaturedOnlyTitleHeaderView.swift */,
+			);
+			path = CustomView;
+			sourceTree = "<group>";
+		};
+		701467852C53C0DA00750A54 /* Layout */ = {
+			isa = PBXGroup;
+			children = (
+				701467862C53C0E600750A54 /* LeftAlignedCollectionViewFlowLayout.swift */,
+			);
+			path = Layout;
+			sourceTree = "<group>";
+		};
+		701467892C53C10600750A54 /* CustomView */ = {
+			isa = PBXGroup;
+			children = (
+				7014678A2C53C11200750A54 /* FeaturedSearchTextField.swift */,
+				7014678C2C53C12400750A54 /* FeaturedRecentSearchHeaderView.swift */,
+				7014678E2C53C13500750A54 /* FeaturedRecentSearchCell.swift */,
+				701467902C53C14600750A54 /* PerformanceInfoCollectionViewCell.swift */,
 			);
 			path = CustomView;
 			sourceTree = "<group>";
@@ -453,6 +482,7 @@
 		7D29811C2C01EB6300A619FB /* Scene */ = {
 			isa = PBXGroup;
 			children = (
+				701467882C53C0FC00750A54 /* Search */,
 				7D89E5462C36650B00E6001E /* Onboarding */,
 				7D1E5FB22C0A20BB0012504D /* Login */,
 				7D1E5FB82C0A27F30012504D /* Tab */,
@@ -777,13 +807,17 @@
 				7D1E5FAD2C0A20950012504D /* LoginViewController.swift in Sources */,
 				7D43E7DA2C57CFDF0008F349 /* OnboardingUseCase.swift in Sources */,
 				7D89E54E2C36673E00E6001E /* OnboardingViewHolder.swift in Sources */,
+				7014678D2C53C12400750A54 /* FeaturedRecentSearchHeaderView.swift in Sources */,
+				7014678B2C53C11200750A54 /* FeaturedSearchTextField.swift in Sources */,
 				7D29813D2C01F28100A619FB /* SampleResponse.swift in Sources */,
 				7D45CB5D2C591D640018FCB8 /* SPLabel.swift in Sources */,
 				7D45CB612C5956C70018FCB8 /* SPButton.swift in Sources */,
 				70B81D602C58D9CB00665EDD /* UIView+CALayer.swift in Sources */,
+				7014678F2C53C13500750A54 /* FeaturedRecentSearchCell.swift in Sources */,
 				7DEACE512C1ED95E00F37DA3 /* KRFont.swift in Sources */,
 				7D89E54A2C36665F00E6001E /* OnboardingViewModel.swift in Sources */,
 				7D29811E2C01EB8A00A619FB /* BaseViewController.swift in Sources */,
+				701467932C53C15800750A54 /* FeaturedSearchViewController.swift in Sources */,
 				7DD2CB7F2C2ED3FA0052ECCD /* FeaturedCoordinator.swift in Sources */,
 				70107B0A2C198E5100F32042 /* LogHelper.swift in Sources */,
 				7D1E5FBA2C0A28080012504D /* MainTabCoordinator.swift in Sources */,
@@ -795,6 +829,7 @@
 				7D45CB632C5A92920018FCB8 /* SPButtonStyle.swift in Sources */,
 				7DEACE4C2C1ECC5200F37DA3 /* CustomFont.swift in Sources */,
 				7014677C2C5363CE00750A54 /* FeaturedPerformanceWithTicketOnSaleSoonCell.swift in Sources */,
+				701467992C53C18C00750A54 /* FeaturedSearchCoordinator.swift in Sources */,
 				7014677E2C5363FB00750A54 /* FeaturedRecommendedPerformanceCell.swift in Sources */,
 				7D29812F2C01F23400A619FB /* SavedViewController.swift in Sources */,
 				7DD2CB832C2ED5510052ECCD /* SavedCoordinator.swift in Sources */,
@@ -815,8 +850,10 @@
 				701467802C53645900750A54 /* FeaturedWatchTheFullPerformanceFooterView.swift in Sources */,
 				7D2981022C01E1D000A619FB /* SceneDelegate.swift in Sources */,
 				7D3196422C133EC90015F88E /* Environment.swift in Sources */,
+				701467972C53C17B00750A54 /* FeaturedSearchViewModel.swift in Sources */,
 				7014673B2C3EFC9300750A54 /* FeaturedSubscribeGenreCell.swift in Sources */,
 				7D13C3522C35A8A30017AE93 /* MainTabController.swift in Sources */,
+				701467872C53C0E600750A54 /* LeftAlignedCollectionViewFlowLayout.swift in Sources */,
 				7DD2CB892C2ED6550052ECCD /* SettingsViewHolder.swift in Sources */,
 				701467392C3EFC8500750A54 /* FeaturedWithButtonHeaderView.swift in Sources */,
 				7DE569F42C5569DF006724EF /* SnackBar.swift in Sources */,
@@ -828,7 +865,10 @@
 				7D8255A72C295E3A00D104BE /* Strings+Generated.swift in Sources */,
 				7D29812D2C01F22B00A619FB /* FeaturedViewModel.swift in Sources */,
 				7D75B91D2C4FE9F500C72417 /* UserDefaultsManager.swift in Sources */,
+				701467912C53C14600750A54 /* PerformanceInfoCollectionViewCell.swift in Sources */,
 				7D2981312C01F23C00A619FB /* SavedViewModel.swift in Sources */,
+				7D2981412C01F29D00A619FB /* SampleUI.swift in Sources */,
+				701467952C53C16900750A54 /* FeaturedSearchViewHolder.swift in Sources */,
 				7D21953F2C143AAA00A38D2B /* ViewModelType.swift in Sources */,
 				7D2195412C143E8400A38D2B /* ViewHolderType.swift in Sources */,
 				7DEACE4E2C1ED00100F37DA3 /* LanguageFont.swift in Sources */,

--- a/ShowPot/ShowPot.xcodeproj/project.pbxproj
+++ b/ShowPot/ShowPot.xcodeproj/project.pbxproj
@@ -57,6 +57,8 @@
 		701467912C53C14600750A54 /* PerformanceInfoCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 701467902C53C14600750A54 /* PerformanceInfoCollectionViewCell.swift */; };
 		701467932C53C15800750A54 /* FeaturedSearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 701467922C53C15800750A54 /* FeaturedSearchViewController.swift */; };
 		701467952C53C16900750A54 /* FeaturedSearchViewHolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 701467942C53C16900750A54 /* FeaturedSearchViewHolder.swift */; };
+		701467972C53C17B00750A54 /* FeaturedSearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 701467962C53C17B00750A54 /* FeaturedSearchViewModel.swift */; };
+		701467992C53C18C00750A54 /* FeaturedSearchCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 701467982C53C18C00750A54 /* FeaturedSearchCoordinator.swift */; };
 		7D1092262C26F36800498C87 /* FlexLayout in Frameworks */ = {isa = PBXBuildFile; productRef = 7D1092252C26F36800498C87 /* FlexLayout */; };
 		7D1092292C26F38800498C87 /* PinLayout in Frameworks */ = {isa = PBXBuildFile; productRef = 7D1092282C26F38800498C87 /* PinLayout */; };
 		7D13C3522C35A8A30017AE93 /* MainTabController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D13C3512C35A8A30017AE93 /* MainTabController.swift */; };
@@ -156,6 +158,8 @@
 		701467902C53C14600750A54 /* PerformanceInfoCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceInfoCollectionViewCell.swift; sourceTree = "<group>"; };
 		701467922C53C15800750A54 /* FeaturedSearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturedSearchViewController.swift; sourceTree = "<group>"; };
 		701467942C53C16900750A54 /* FeaturedSearchViewHolder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturedSearchViewHolder.swift; sourceTree = "<group>"; };
+		701467962C53C17B00750A54 /* FeaturedSearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturedSearchViewModel.swift; sourceTree = "<group>"; };
+		701467982C53C18C00750A54 /* FeaturedSearchCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturedSearchCoordinator.swift; sourceTree = "<group>"; };
 		7D13C3512C35A8A30017AE93 /* MainTabController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabController.swift; sourceTree = "<group>"; };
 		7D1E5FAC2C0A20950012504D /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		7D1E5FAE2C0A20A10012504D /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
@@ -327,6 +331,8 @@
 				701467892C53C10600750A54 /* CustomView */,
 				701467922C53C15800750A54 /* FeaturedSearchViewController.swift */,
 				701467942C53C16900750A54 /* FeaturedSearchViewHolder.swift */,
+				701467962C53C17B00750A54 /* FeaturedSearchViewModel.swift */,
+				701467982C53C18C00750A54 /* FeaturedSearchCoordinator.swift */,
 			);
 			path = Search;
 			sourceTree = "<group>";

--- a/ShowPot/ShowPot/Common/UI/Layout/LeftAlignedCollectionViewFlowLayout.swift
+++ b/ShowPot/ShowPot/Common/UI/Layout/LeftAlignedCollectionViewFlowLayout.swift
@@ -2,7 +2,7 @@
 //  LeftAlignedCollectionViewFlowLayout.swift
 //  ShowPot
 //
-//  Created by 이건준 on 7/23/24.
+//  Created by 이건준 on 7/30/24.
 //
 
 import UIKit

--- a/ShowPot/ShowPot/Common/UI/Layout/LeftAlignedCollectionViewFlowLayout.swift
+++ b/ShowPot/ShowPot/Common/UI/Layout/LeftAlignedCollectionViewFlowLayout.swift
@@ -1,0 +1,29 @@
+//
+//  LeftAlignedCollectionViewFlowLayout.swift
+//  ShowPot
+//
+//  Created by 이건준 on 7/23/24.
+//
+
+import UIKit
+
+/// UICollectionViewCell 왼쪽정렬시켜주는 flowLayout
+final class LeftAlignedCollectionViewFlowLayout: UICollectionViewFlowLayout {
+    override func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
+        let attributes = super.layoutAttributesForElements(in: rect)
+        
+        var leftMargin = sectionInset.left
+        var maxY: CGFloat = -1.0
+        attributes?.forEach { layoutAttribute in
+            if layoutAttribute.representedElementCategory == .cell {
+                if layoutAttribute.frame.origin.y >= maxY {
+                    leftMargin = sectionInset.left
+                }
+                layoutAttribute.frame.origin.x = leftMargin
+                leftMargin += layoutAttribute.frame.width + minimumInteritemSpacing
+                maxY = max(layoutAttribute.frame.maxY, maxY)
+            }
+        }
+        return attributes
+    }
+}

--- a/ShowPot/ShowPot/Data/UserDefaults/UserDefaultsKey.swift
+++ b/ShowPot/ShowPot/Data/UserDefaults/UserDefaultsKey.swift
@@ -12,6 +12,9 @@ enum UserDefaultsKey: String {
     /// 최초 실행 여부
     case firstLaunch
     
+    /// 최근 검색어 리스트
+    case recentSearchQueryList
+    
     var value: String {
         return self.rawValue
     }

--- a/ShowPot/ShowPot/Data/UserDefaults/UserDefaultsKey.swift
+++ b/ShowPot/ShowPot/Data/UserDefaults/UserDefaultsKey.swift
@@ -13,7 +13,7 @@ enum UserDefaultsKey: String {
     case firstLaunch
     
     /// 최근 검색어 리스트
-    case recentSearchQueryList
+    case recentSearchKeywordList
     
     var value: String {
         return self.rawValue

--- a/ShowPot/ShowPot/Presentation/Scene/Login/LoginViewHolder.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Login/LoginViewHolder.swift
@@ -21,10 +21,9 @@ final class LoginViewHolder {
         $0.contentMode = .scaleAspectFit
     }
     
-    let alertLabel = SPLabel(KRFont.H2).then {
+    let alertLabel = SPLabel(KRFont.H2, alignment: .center).then {
         $0.textColor = .gray000
         $0.setText(Strings.socialLoginDescription)
-        $0.textAlignment = .center
     }
     
     let loginImageView = UIImageView().then {

--- a/ShowPot/ShowPot/Presentation/Scene/Search/CustomView/FeaturedRecentSearchCell.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Search/CustomView/FeaturedRecentSearchCell.swift
@@ -69,7 +69,7 @@ struct FeaturedRecentSearchCellModel {
 
 extension FeaturedRecentSearchCell {
     func configureUI(with model: FeaturedRecentSearchCellModel) {
-        recentSearchQueryLabel.setAttributedText(font: KRFont.self, string: model.recentSearchQuery) // TODO: - 한글, 영어에 따라 다르게 적용되는지 확인필요
+        recentSearchQueryLabel.setAttributedText(font: KRFont.self, string: model.recentSearchQuery) 
         recentSearchQueryLabel.lineBreakMode = .byTruncatingTail // TODO: - attribute적용 이후 lineBreakMode적용안되는 문제 해결 필요
     }
 }

--- a/ShowPot/ShowPot/Presentation/Scene/Search/CustomView/FeaturedRecentSearchCell.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Search/CustomView/FeaturedRecentSearchCell.swift
@@ -1,0 +1,75 @@
+//
+//  FeaturedRecentSearchCell.swift
+//  ShowPot
+//
+//  Created by 이건준 on 7/22/24.
+//
+
+import UIKit
+
+import RxSwift
+import SnapKit
+import Then
+
+final class FeaturedRecentSearchCell: UICollectionViewCell, ReusableCell {
+    
+    var didTappedXButton: Observable<Void> {
+        xButton.rx.tap.asObservable()
+    }
+    
+    private let recentSearchQueryLabel = UILabel().then {
+        $0.textColor = .white
+        $0.font = KRFont.B1_regular
+    }
+    
+    private let xButton = UIButton().then {
+        $0.setImage(.icCancel.withTintColor(.gray300), for: .normal)
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupStyles()
+        setupLayouts()
+        setupConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupStyles() {
+        contentView.backgroundColor = .gray700
+        contentView.layer.masksToBounds = true
+        contentView.layer.cornerRadius = 18
+        contentView.layer.borderColor = UIColor.gray400.cgColor
+        contentView.layer.borderWidth = 1
+    }
+    
+    private func setupLayouts() {
+        [recentSearchQueryLabel, xButton].forEach { contentView.addSubview($0) }
+    }
+    
+    private func setupConstraints() {
+        recentSearchQueryLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(14)
+            $0.directionalVerticalEdges.equalToSuperview().inset(8)
+        }
+        
+        xButton.snp.makeConstraints {
+            $0.directionalVerticalEdges.trailing.equalToSuperview().inset(8)
+            $0.leading.equalTo(recentSearchQueryLabel.snp.trailing)
+            $0.size.equalTo(24)
+        }
+    }
+}
+
+struct FeaturedRecentSearchCellModel {
+    let recentSearchQuery: String
+}
+
+extension FeaturedRecentSearchCell {
+    func configureUI(with model: FeaturedRecentSearchCellModel) {
+        recentSearchQueryLabel.setAttributedText(font: KRFont.self, string: model.recentSearchQuery) // TODO: - 한글, 영어에 따라 다르게 적용되는지 확인필요
+        recentSearchQueryLabel.lineBreakMode = .byTruncatingTail // TODO: - attribute적용 이후 lineBreakMode적용안되는 문제 해결 필요
+    }
+}

--- a/ShowPot/ShowPot/Presentation/Scene/Search/CustomView/FeaturedRecentSearchCell.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Search/CustomView/FeaturedRecentSearchCell.swift
@@ -11,18 +11,18 @@ import RxSwift
 import SnapKit
 import Then
 
+/// 최근검색키워드에 대한 셀
 final class FeaturedRecentSearchCell: UICollectionViewCell, ReusableCell {
     
-    var didTappedXButton: Observable<Void> {
-        xButton.rx.tap.asObservable()
+    var didTappedRemoveKeywordButton: Observable<Void> {
+        removeKeywordButton.rx.tap.asObservable()
     }
     
-    private let recentSearchQueryLabel = UILabel().then {
-        $0.textColor = .white
-        $0.font = KRFont.B1_regular
+    private let recentSearchKeywordLabel = SPLabel(KRFont.B1_regular).then {
+        $0.textColor = .gray000
     }
     
-    private let xButton = UIButton().then {
+    private let removeKeywordButton = UIButton().then {
         $0.setImage(.icCancel.withTintColor(.gray300), for: .normal)
     }
     
@@ -46,30 +46,25 @@ final class FeaturedRecentSearchCell: UICollectionViewCell, ReusableCell {
     }
     
     private func setupLayouts() {
-        [recentSearchQueryLabel, xButton].forEach { contentView.addSubview($0) }
+        [recentSearchKeywordLabel, removeKeywordButton].forEach { contentView.addSubview($0) }
     }
     
     private func setupConstraints() {
-        recentSearchQueryLabel.snp.makeConstraints {
+        recentSearchKeywordLabel.snp.makeConstraints {
             $0.leading.equalToSuperview().inset(14)
             $0.directionalVerticalEdges.equalToSuperview().inset(8)
         }
         
-        xButton.snp.makeConstraints {
+        removeKeywordButton.snp.makeConstraints {
             $0.directionalVerticalEdges.trailing.equalToSuperview().inset(8)
-            $0.leading.equalTo(recentSearchQueryLabel.snp.trailing)
+            $0.leading.equalTo(recentSearchKeywordLabel.snp.trailing)
             $0.size.equalTo(24)
         }
     }
 }
 
-struct FeaturedRecentSearchCellModel {
-    let recentSearchQuery: String
-}
-
 extension FeaturedRecentSearchCell {
-    func configureUI(with model: FeaturedRecentSearchCellModel) {
-        recentSearchQueryLabel.setAttributedText(font: KRFont.self, string: model.recentSearchQuery) 
-        recentSearchQueryLabel.lineBreakMode = .byTruncatingTail // TODO: - attribute적용 이후 lineBreakMode적용안되는 문제 해결 필요
+    func configureUI(with searchKeyword: String) {
+        recentSearchKeywordLabel.setText(searchKeyword)
     }
 }

--- a/ShowPot/ShowPot/Presentation/Scene/Search/CustomView/FeaturedRecentSearchHeaderView.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Search/CustomView/FeaturedRecentSearchHeaderView.swift
@@ -11,26 +11,25 @@ import RxSwift
 import SnapKit
 import Then
 
-final class FeaturedRecentSearchHeaderView: UICollectionReusableView {
+/// 최근 검색리스트에 대한 헤더뷰
+final class FeaturedRecentSearchHeaderView: UICollectionReusableView, ReusableCell {
     
-    static let identifier = String(describing: FeaturedRecentSearchHeaderView.self)
     private let disposeBag = DisposeBag()
     
     var didTappedRemoveAllButton: Observable<Void> {
         removeAllButton.rx.tap.asObservable()
     }
     
-    private let recentSearchLabel = UILabel().then {
-        $0.text = Strings.searchQueryTitle
+    private let recentSearchLabel = SPLabel(KRFont.H2).then {
         $0.textColor = .gray100
-        $0.textAlignment = .left
-        $0.font = KRFont.H2
+        $0.setText(Strings.searchKeywordTitle)
     }
     
-    private let removeAllButton = UIButton().then {
-        $0.setTitle(Strings.searchQueryButtonTitle, for: .normal)
-        $0.setTitleColor(.gray400, for: .normal)
-        $0.titleLabel?.font = KRFont.B1_regular
+    private let removeAllButton = SPButton().then { 
+        $0.setText(Strings.searchKeywordButtonTitle, fontType: KRFont.B1_regular)
+        $0.configuration?.baseForegroundColor = .gray400
+        $0.configuration?.baseBackgroundColor = .clear
+        $0.configuration?.contentInsets = .zero
     }
     
     override init(frame: CGRect) {
@@ -57,7 +56,6 @@ final class FeaturedRecentSearchHeaderView: UICollectionReusableView {
             $0.leading.equalTo(recentSearchLabel.snp.trailing)
             $0.directionalVerticalEdges.equalToSuperview()
             $0.trailing.equalToSuperview().inset(16)
-            $0.width.equalTo(59)
         }
     }
 }

--- a/ShowPot/ShowPot/Presentation/Scene/Search/CustomView/FeaturedRecentSearchHeaderView.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Search/CustomView/FeaturedRecentSearchHeaderView.swift
@@ -21,14 +21,14 @@ final class FeaturedRecentSearchHeaderView: UICollectionReusableView {
     }
     
     private let recentSearchLabel = UILabel().then {
-        $0.text = "최근검색어"
+        $0.text = Strings.searchQueryTitle
         $0.textColor = .gray100
         $0.textAlignment = .left
         $0.font = KRFont.H2
     }
     
     private let removeAllButton = UIButton().then {
-        $0.setTitle("모두삭제", for: .normal)
+        $0.setTitle(Strings.searchQueryButtonTitle, for: .normal)
         $0.setTitleColor(.gray400, for: .normal)
         $0.titleLabel?.font = KRFont.B1_regular
     }

--- a/ShowPot/ShowPot/Presentation/Scene/Search/CustomView/FeaturedRecentSearchHeaderView.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Search/CustomView/FeaturedRecentSearchHeaderView.swift
@@ -1,0 +1,63 @@
+//
+//  FeaturedSearchHeaderView.swift
+//  ShowPot
+//
+//  Created by 이건준 on 7/22/24.
+//
+
+import UIKit
+
+import RxSwift
+import SnapKit
+import Then
+
+final class FeaturedRecentSearchHeaderView: UICollectionReusableView {
+    
+    static let identifier = String(describing: FeaturedRecentSearchHeaderView.self)
+    private let disposeBag = DisposeBag()
+    
+    var didTappedRemoveAllButton: Observable<Void> {
+        removeAllButton.rx.tap.asObservable()
+    }
+    
+    private let recentSearchLabel = UILabel().then {
+        $0.text = "최근검색어"
+        $0.textColor = .gray100
+        $0.textAlignment = .left
+        $0.font = KRFont.H2
+    }
+    
+    private let removeAllButton = UIButton().then {
+        $0.setTitle("모두삭제", for: .normal)
+        $0.setTitleColor(.gray400, for: .normal)
+        $0.titleLabel?.font = KRFont.B1_regular
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupLayouts()
+        setupConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupLayouts() {
+        [recentSearchLabel, removeAllButton].forEach { addSubview($0) }
+    }
+    
+    private func setupConstraints() {
+        recentSearchLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(16)
+            $0.directionalVerticalEdges.equalToSuperview()
+        }
+        
+        removeAllButton.snp.makeConstraints {
+            $0.leading.equalTo(recentSearchLabel.snp.trailing)
+            $0.directionalVerticalEdges.equalToSuperview()
+            $0.trailing.equalToSuperview().inset(16)
+            $0.width.equalTo(59)
+        }
+    }
+}

--- a/ShowPot/ShowPot/Presentation/Scene/Search/CustomView/FeaturedSearchTextField.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Search/CustomView/FeaturedSearchTextField.swift
@@ -1,0 +1,118 @@
+//
+//  FeaturedSearchTextField.swift
+//  ShowPot
+//
+//  Created by 이건준 on 7/22/24.
+//
+
+import UIKit
+
+import RxSwift
+import SnapKit
+import Then
+
+final class FeaturedSearchTextField: UITextField {
+    
+    private let disposeBag = DisposeBag()
+    
+    var didTappedXButton: Observable<Void> {
+        xButton.rx.tap.asObservable().share(replay: 1)
+    }
+    
+    var didTappedReturnButton: Observable<String> {
+        rx.controlEvent(.editingDidEndOnExit).asObservable()
+            .withUnretained(self)
+            .filter { $0.0.returnKeyType == .search }
+            .compactMap { $0.0.text }
+            .share(replay: 1)
+    }
+    
+    private let xButton = UIButton().then {
+        $0.setImage(.icCancel.withTintColor(.white), for: .normal)
+        $0.backgroundColor = .clear
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupStyles()
+        bind()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupStyles() {
+        delegate = self
+        becomeFirstResponder()
+        
+        textColor = .white
+        tintColor = .white
+        backgroundColor = .gray500
+        layer.masksToBounds = true
+        layer.cornerRadius = 2
+        
+        returnKeyType = .default
+        autocorrectionType = .no
+        spellCheckingType = .no
+        autocapitalizationType = .sentences
+        
+        leftViewMode = .always
+        leftView = UIView(frame: .init(x: .zero, y: .zero, width: 8, height: .zero))
+        
+        clearButtonMode = .never
+        
+        rightViewMode = .always
+        rightView = xButton
+    }
+    
+    private func bind() {
+        xButton.rx.tap
+            .subscribe(with: self) { owner, _ in
+                owner.text?.removeAll()
+                owner.updateReturnKey(type: .default)
+            }
+            .disposed(by: disposeBag)
+        
+        didTappedReturnButton
+            .subscribe(with: self) { owner, _ in
+                owner.resignFirstResponder()
+            }
+            .disposed(by: disposeBag)
+    }
+}
+
+// MARK: - FeaturedSearchTextField Helper
+
+extension FeaturedSearchTextField {
+    private func updateReturnKey(type: UIReturnKeyType) {
+        self.returnKeyType = type
+        self.reloadInputViews()
+    }
+}
+
+// MARK: - FeaturedSearchTextField UITextFieldDelegate
+
+extension FeaturedSearchTextField: UITextFieldDelegate {
+    
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        if let text = textField.text as NSString? {
+            let newText = text.replacingCharacters(in: range, with: string)
+            let isEmpty = newText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            updateReturnKey(type: isEmpty ? .default : .search)
+        }
+        return true
+    }
+}
+
+// MARK: - FeaturedSearchTextField Padding
+
+extension FeaturedSearchTextField {
+    
+    override func rightViewRect(forBounds bounds: CGRect) -> CGRect {
+        var padding = super.rightViewRect(forBounds: bounds)
+        padding.origin.x -= 5
+        
+        return padding
+    }
+}

--- a/ShowPot/ShowPot/Presentation/Scene/Search/CustomView/FeaturedSearchTextField.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Search/CustomView/FeaturedSearchTextField.swift
@@ -71,6 +71,7 @@ final class FeaturedSearchTextField: UITextField {
             .subscribe(with: self) { owner, _ in
                 owner.text?.removeAll()
                 owner.updateReturnKey(type: .default)
+                owner.searchTextFieldDelegate?.didTappedXButton()
             }
             .disposed(by: disposeBag)
         

--- a/ShowPot/ShowPot/Presentation/Scene/Search/CustomView/FeaturedSearchTextField.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Search/CustomView/FeaturedSearchTextField.swift
@@ -11,15 +11,16 @@ import RxSwift
 import SnapKit
 import Then
 
+/// 검색화면에서 키워드 검색하기위한 UITextField
 final class FeaturedSearchTextField: UITextField {
     
     private let disposeBag = DisposeBag()
     
-    var didTappedXButton: Observable<Void> {
-        xButton.rx.tap.asObservable().share(replay: 1)
+    var didTappedRemoveAllButton: Observable<Void> {
+        removeAllButton.rx.tap.asObservable().share(replay: 1)
     }
     
-    var didTappedReturnButton: Observable<String> {
+    var didTappedReturnKey: Observable<String> {
         rx.controlEvent(.editingDidEndOnExit).asObservable()
             .withUnretained(self)
             .filter { $0.0.returnKeyType == .search }
@@ -27,8 +28,8 @@ final class FeaturedSearchTextField: UITextField {
             .share(replay: 1)
     }
     
-    private let xButton = UIButton().then {
-        $0.setImage(.icCancel.withTintColor(.white), for: .normal)
+    private let removeAllButton = UIButton().then {
+        $0.setImage(.icCancel.withTintColor(.gray000), for: .normal)
         $0.backgroundColor = .clear
     }
     
@@ -46,8 +47,8 @@ final class FeaturedSearchTextField: UITextField {
         delegate = self
         becomeFirstResponder()
         
-        textColor = .white
-        tintColor = .white
+        textColor = .gray000
+        tintColor = .gray000
         backgroundColor = .gray500
         layer.masksToBounds = true
         layer.cornerRadius = 2
@@ -63,19 +64,18 @@ final class FeaturedSearchTextField: UITextField {
         clearButtonMode = .never
         
         rightViewMode = .always
-        rightView = xButton
+        rightView = removeAllButton
     }
     
     private func bind() {
-        xButton.rx.tap
+        didTappedRemoveAllButton
             .subscribe(with: self) { owner, _ in
                 owner.text?.removeAll()
                 owner.updateReturnKey(type: .default)
-                owner.searchTextFieldDelegate?.didTappedXButton()
             }
             .disposed(by: disposeBag)
         
-        didTappedReturnButton
+        didTappedReturnKey
             .subscribe(with: self) { owner, _ in
                 owner.resignFirstResponder()
             }

--- a/ShowPot/ShowPot/Presentation/Scene/Search/CustomView/PerformanceInfoCollectionViewCell.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Search/CustomView/PerformanceInfoCollectionViewCell.swift
@@ -1,0 +1,100 @@
+//
+//  PerformanceInfoCollectionViewCell.swift
+//  ShowPot
+//
+//  Created by 이건준 on 7/24/24.
+//
+
+import UIKit
+
+import Kingfisher
+import SnapKit
+import Then
+
+final class PerformanceInfoCollectionViewCell: UICollectionViewCell, ReusableCell {
+    
+    private let performanceImageView = UIImageView().then {
+        $0.contentMode = .scaleAspectFill
+        $0.layer.masksToBounds = true
+    }
+    
+    private let performanceTitleLabel = UILabel().then {
+        $0.textColor = .white
+        $0.font = ENFont.H2
+    }
+    
+    private let performanceTimeLabel = UILabel().then {
+        $0.textColor = .gray200
+        $0.font = KRFont.B3_regular
+    }
+    
+    private let performanceLocationLabel = UILabel().then {
+        $0.textColor = .gray200
+        $0.font = KRFont.B3_regular
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupLayouts()
+        setupConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupLayouts() {
+        [performanceImageView, performanceTitleLabel, performanceTimeLabel, performanceLocationLabel].forEach { contentView.addSubview($0) }
+    }
+    
+    private func setupConstraints() {
+        performanceImageView.snp.makeConstraints {
+            $0.leading.directionalVerticalEdges.equalToSuperview()
+            $0.size.equalTo(80)
+        }
+        
+        performanceTitleLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(3)
+            $0.leading.equalTo(performanceImageView.snp.trailing).offset(14)
+            $0.trailing.lessThanOrEqualToSuperview()
+            $0.height.equalTo(33)
+        }
+        
+        performanceTimeLabel.snp.makeConstraints {
+            $0.leading.equalTo(performanceTitleLabel)
+            $0.trailing.lessThanOrEqualToSuperview()
+            $0.top.equalTo(performanceTitleLabel.snp.bottom).offset(5)
+            $0.height.equalTo(18)
+        }
+        
+        performanceLocationLabel.snp.makeConstraints {
+            $0.leading.equalTo(performanceTimeLabel)
+            $0.trailing.lessThanOrEqualToSuperview()
+            $0.top.equalTo(performanceTimeLabel.snp.bottom).offset(1)
+            $0.bottom.equalToSuperview().inset(2)
+            $0.height.equalTo(18)
+        }
+    }
+}
+
+struct PerformanceInfoCollectionViewCellModel: Hashable {
+    let performanceImageURL: URL?
+    let performanceTitle: String
+    let performanceTime: String
+    let performanceLocation: String
+    
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(identifier)
+    }
+    
+    private let identifier = UUID() // TODO: - 추후 공연정보에 대한 아이디로 대체
+}
+
+extension PerformanceInfoCollectionViewCell {
+    func configureUI(with model: PerformanceInfoCollectionViewCellModel) {
+        performanceImageView.kf.setImage(with: model.performanceImageURL)
+        performanceTitleLabel.setAttributedText(font: ENFont.self, string: model.performanceTitle)
+        performanceTimeLabel.setAttributedText(font: KRFont.self, string: model.performanceTime)
+        performanceLocationLabel.setAttributedText(font: KRFont.self, string: model.performanceLocation)
+    }
+}

--- a/ShowPot/ShowPot/Presentation/Scene/Search/CustomView/PerformanceInfoCollectionViewCell.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Search/CustomView/PerformanceInfoCollectionViewCell.swift
@@ -11,6 +11,7 @@ import Kingfisher
 import SnapKit
 import Then
 
+/// 공연정보에 대한 셀
 final class PerformanceInfoCollectionViewCell: UICollectionViewCell, ReusableCell {
     
     private let performanceImageView = UIImageView().then {
@@ -18,19 +19,16 @@ final class PerformanceInfoCollectionViewCell: UICollectionViewCell, ReusableCel
         $0.layer.masksToBounds = true
     }
     
-    private let performanceTitleLabel = UILabel().then {
-        $0.textColor = .white
-        $0.font = ENFont.H2
+    private let performanceTitleLabel = SPLabel(ENFont.H2).then {
+        $0.textColor = .gray000
     }
     
-    private let performanceTimeLabel = UILabel().then {
+    private let performanceTimeLabel = SPLabel(KRFont.B3_regular).then {
         $0.textColor = .gray200
-        $0.font = KRFont.B3_regular
     }
     
-    private let performanceLocationLabel = UILabel().then {
+    private let performanceLocationLabel = SPLabel(KRFont.B3_regular).then {
         $0.textColor = .gray200
-        $0.font = KRFont.B3_regular
     }
     
     override init(frame: CGRect) {
@@ -80,7 +78,7 @@ final class PerformanceInfoCollectionViewCell: UICollectionViewCell, ReusableCel
 struct PerformanceInfoCollectionViewCellModel: Hashable {
     let performanceImageURL: URL?
     let performanceTitle: String
-    let performanceTime: String
+    let performanceTime: Date?
     let performanceLocation: String
     
     func hash(into hasher: inout Hasher) {
@@ -92,9 +90,31 @@ struct PerformanceInfoCollectionViewCellModel: Hashable {
 
 extension PerformanceInfoCollectionViewCell {
     func configureUI(with model: PerformanceInfoCollectionViewCellModel) {
+        
+        let dateFormatter = DateFormatter() // TODO: #95 Date관련 공통함수로 코드 개선
+        dateFormatter.dateFormat = "yyyy.MM.d"
+        dateFormatter.locale = Locale(identifier: "en_US")
+        
         performanceImageView.kf.setImage(with: model.performanceImageURL)
-        performanceTitleLabel.setAttributedText(font: ENFont.self, string: model.performanceTitle)
-        performanceTimeLabel.setAttributedText(font: KRFont.self, string: model.performanceTime)
-        performanceLocationLabel.setAttributedText(font: KRFont.self, string: model.performanceLocation)
+        performanceTitleLabel.setText(model.performanceTitle)
+        performanceTimeLabel.setText(dateFormatter.string(from: model.performanceTime ?? Date()))
+        performanceLocationLabel.setText(model.performanceLocation)
+    }
+    
+    func configureUI(
+        performanceImageURL: URL?,
+        performanceTitle: String,
+        performanceTime: Date?,
+        performanceLocation: String
+    ) {
+        
+        let dateFormatter = DateFormatter() // TODO: #95 Date관련 공통함수로 코드 개선
+        dateFormatter.dateFormat = "yyyy.MM.d"
+        dateFormatter.locale = Locale(identifier: "en_US")
+        
+        performanceImageView.kf.setImage(with: performanceImageURL)
+        performanceTitleLabel.setText(performanceTitle)
+        performanceTimeLabel.setText(dateFormatter.string(from: performanceTime ?? Date()))
+        performanceLocationLabel.setText(performanceLocation)
     }
 }

--- a/ShowPot/ShowPot/Presentation/Scene/Search/FeaturedSearchCoordinator.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Search/FeaturedSearchCoordinator.swift
@@ -1,0 +1,30 @@
+//
+//  FeaturedSearchCoordinator.swift
+//  ShowPot
+//
+//  Created by 이건준 on 7/22/24.
+//
+
+import UIKit
+
+final class FeaturedSearchCoordinator: NavigationCoordinator {
+    
+    var navigationController: UINavigationController
+    var parentCoordinator: Coordinator?
+    var childCoordinators: [Coordinator] = []
+    
+    init(navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+    
+    func start() {
+        let viewController: FeaturedSearchViewController = FeaturedSearchViewController(viewModel: FeaturedSearchViewModel(coordinator: self))
+        self.navigationController.pushViewController(viewController, animated: true)
+    }
+    
+    func popViewController() {
+        LogHelper.debug("홈 화면으로 pop 호출")
+        self.parentCoordinator?.removeChildCoordinator(child: self)
+        self.navigationController.popViewController(animated: true)
+    }
+}

--- a/ShowPot/ShowPot/Presentation/Scene/Search/FeaturedSearchViewController.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Search/FeaturedSearchViewController.swift
@@ -1,0 +1,63 @@
+//
+//  FeaturedSearchViewController.swift
+//  ShowPot
+//
+//  Created by 이건준 on 7/22/24.
+//
+
+import UIKit
+
+import RxSwift
+import SnapKit
+import Then
+
+final class FeaturedSearchViewController: ViewController {
+    let viewHolder: FeaturedSearchViewHolder = .init()
+    let viewModel: FeaturedSearchViewModel
+    init(viewModel: FeaturedSearchViewModel) {
+        self.viewModel = viewModel
+        
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        viewHolderConfigure()
+    }
+    
+    override func setupStyles() {
+        view.backgroundColor = .gray700
+        viewHolder.recentSearchCollectionView.delegate = self
+        viewHolder.searchQueryResultCollectionView.delegate = self
+        viewHolder.featuredSearchTextField.searchTextFieldDelegate = self
+// MARK: - UICollectionViewDelegateFlowLayout
+
+extension FeaturedSearchViewController: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        if collectionView == viewHolder.recentSearchCollectionView {
+            let label = UILabel().then {
+                $0.font = KRFont.B1_regular
+                $0.setAttributedText(font: KRFont.self, string: viewModel.recentSearchQueryList[indexPath.row])
+                $0.sizeToFit()
+            }
+            let size = label.frame.size
+            let maxWidth = UIScreen.main.bounds.width - 32
+            let additionalWidth: CGFloat = 24 + 14 + 8
+            let width = min(maxWidth, additionalWidth + size.width)
+            return CGSize(width: width, height: 40)
+        }
+        return CGSize(width: collectionView.frame.width - 32, height: 80)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
+        if collectionView == viewHolder.recentSearchCollectionView {
+            return .init(width: collectionView.frame.width, height: 44)
+        }
+        return .zero
+    }
+}
+    }

--- a/ShowPot/ShowPot/Presentation/Scene/Search/FeaturedSearchViewController.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Search/FeaturedSearchViewController.swift
@@ -14,6 +14,10 @@ import Then
 final class FeaturedSearchViewController: ViewController {
     let viewHolder: FeaturedSearchViewHolder = .init()
     let viewModel: FeaturedSearchViewModel
+        
+    private let didTappedRemoveAllButtonSubject = PublishSubject<Void>()
+    private let didTappedRecentSearchQueryXbuttonSubject = PublishSubject<String>()
+    
     init(viewModel: FeaturedSearchViewModel) {
         self.viewModel = viewModel
         
@@ -33,15 +37,67 @@ final class FeaturedSearchViewController: ViewController {
         view.backgroundColor = .gray700
         viewHolder.recentSearchCollectionView.delegate = self
         viewHolder.searchQueryResultCollectionView.delegate = self
-        viewHolder.featuredSearchTextField.searchTextFieldDelegate = self
+        
+        viewModel.recentSearchQueryDataSource = makeRecentSearchQueryDataSource()
+        viewModel.searchQueryResultDataSource = makeSearchQueryResultDataSource()
+    }
+    
+    override func bind() {
+        
+        let itemSelected = viewHolder.recentSearchCollectionView.rx.itemSelected.asObservable().share()
+        itemSelected.subscribe(with: self) { owner, indexPath in
+            guard let model = owner.viewModel.recentSearchQueryDataSource?.snapshot().itemIdentifiers[indexPath.row] else { return }
+            owner.viewHolder.featuredSearchTextField.resignFirstResponder()
+            owner.viewHolder.featuredSearchTextField.text = model
+        }
+        .disposed(by: disposeBag)
+        
+        let input = FeaturedSearchViewModel.Input(
+            requestInitialSearchQueryData: .just(()),
+            didTappedBackButton: viewHolder.backButton.rx.tap.asObservable(),
+            didTappedRemoveAllButton: didTappedRemoveAllButtonSubject.asObservable(),
+            didTappedRecentSearchQuery: itemSelected,
+            didTappedRecentSearchQueryXButton: didTappedRecentSearchQueryXbuttonSubject.asObservable(),
+            didTappedReturnKey: viewHolder.featuredSearchTextField.didTappedReturnButton,
+            searchQueryTextField: viewHolder.featuredSearchTextField.rx.text.orEmpty,
+            didTappedSearchTextFieldXButton: viewHolder.featuredSearchTextField.didTappedXButton,
+            didTappedSearchResultCell: viewHolder.searchQueryResultCollectionView.rx.itemSelected.asObservable()
+        )
+        let output = viewModel.transform(input: input)
+        
+        output.isRecentSearchQueryListEmpty
+            .map { !$0 }
+            .drive(viewHolder.emptyLabel.rx.isHidden)
+            .disposed(by: disposeBag)
+        
+        output.isSearchResultEmpty
+            .drive(viewHolder.searchQueryResultCollectionView.rx.isHidden)
+            .disposed(by: disposeBag)
+        
+        output.isLoading
+            .drive(viewHolder.indicatorView.rx.isAnimating)
+            .disposed(by: disposeBag)
+        
+        viewHolder.searchQueryResultCollectionView.rx.didScroll
+            .subscribe(with: self) { owner, _ in
+                let isFirstResponder = owner.viewHolder.featuredSearchTextField.isFirstResponder
+                if isFirstResponder {
+                    owner.viewHolder.featuredSearchTextField.resignFirstResponder()
+                }
+            }
+            .disposed(by: disposeBag)
+    }
+}
+
 // MARK: - UICollectionViewDelegateFlowLayout
 
 extension FeaturedSearchViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         if collectionView == viewHolder.recentSearchCollectionView {
+            guard let string = viewModel.recentSearchQueryDataSource?.snapshot().itemIdentifiers[indexPath.row] else { return .zero }
             let label = UILabel().then {
                 $0.font = KRFont.B1_regular
-                $0.setAttributedText(font: KRFont.self, string: viewModel.recentSearchQueryList[indexPath.row])
+                $0.setAttributedText(font: KRFont.self, string: string)
                 $0.sizeToFit()
             }
             let size = label.frame.size
@@ -49,15 +105,94 @@ extension FeaturedSearchViewController: UICollectionViewDelegateFlowLayout {
             let additionalWidth: CGFloat = 24 + 14 + 8
             let width = min(maxWidth, additionalWidth + size.width)
             return CGSize(width: width, height: 40)
+        } else if collectionView == viewHolder.searchQueryResultCollectionView {
+            guard let type = viewModel.searchQueryResultDataSource?.snapshot().sectionIdentifiers[indexPath.section] else { return .zero }
+            switch type {
+            case .artistList:
+                return CGSize(width: 100, height: 129)
+            case .performanceInfo:
+                return CGSize(width: collectionView.frame.width - 32, height: 80)
+            }
         }
-        return CGSize(width: collectionView.frame.width - 32, height: 80)
+        return .zero
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
         if collectionView == viewHolder.recentSearchCollectionView {
             return .init(width: collectionView.frame.width, height: 44)
+        } else if collectionView == viewHolder.searchQueryResultCollectionView {
+            return .init(width: collectionView.frame.width - 32, height: 44)
         }
         return .zero
     }
 }
+
+// MARK: - Helper For NSDiffableDataSource
+
+extension FeaturedSearchViewController {
+    func makeRecentSearchQueryDataSource() -> FeaturedSearchViewModel.RecentSearchQueryDataSource {
+        let cellRegistration = UICollectionView.CellRegistration<FeaturedRecentSearchCell, String> { [weak self] (cell, indexPath, searchQuery) in
+            guard let self else { return }
+            cell.configureUI(with: .init(recentSearchQuery: searchQuery))
+            cell.didTappedXButton
+                .take(1)
+                .subscribe(with: self) { owner, _ in
+                    owner.didTappedRecentSearchQueryXbuttonSubject.onNext(searchQuery)
+                }
+                .disposed(by: disposeBag)
+        }
+        
+        let headerRegistration = UICollectionView.SupplementaryRegistration<FeaturedRecentSearchHeaderView>(elementKind: UICollectionView.elementKindSectionHeader) { [weak self] supplementaryView, _, _ in
+            guard let self = self else { return }
+            supplementaryView.didTappedRemoveAllButton
+                .bind(to: self.didTappedRemoveAllButtonSubject)
+                .disposed(by: disposeBag)
+        }
+        
+        let dataSource = UICollectionViewDiffableDataSource<FeaturedSearchViewModel.RecentSearchSection, String>(collectionView: viewHolder.recentSearchCollectionView) { (collectionView, indexPath, searchQuery) -> UICollectionViewCell? in
+            return collectionView.dequeueConfiguredReusableCell(using: cellRegistration, for: indexPath, item: searchQuery)
+        }
+        
+        dataSource.supplementaryViewProvider = .init { collectionView, elementKind, indexPath in
+            return collectionView.dequeueConfiguredReusableSupplementary(using: headerRegistration, for: indexPath)
+        }
+        
+        return dataSource
     }
+    
+    func makeSearchQueryResultDataSource() -> FeaturedSearchViewModel.SearchQueryResultDataSource {
+        
+        let artistCellRegistration = UICollectionView.CellRegistration<FeaturedSubscribeArtistCell, FeaturedSubscribeArtistCellModel> { (cell, indexPath, model) in
+            cell.configureUI(with: model)
+        }
+        
+        let performanceCellRegistration = UICollectionView.CellRegistration<PerformanceInfoCollectionViewCell, PerformanceInfoCollectionViewCellModel> { (cell, indexPath, model) in
+            cell.configureUI(with: model)
+        }
+        
+        let headerRegistration = UICollectionView.SupplementaryRegistration<FeaturedOnlyTitleHeaderView>(elementKind: UICollectionView.elementKindSectionHeader) { [weak self] supplementaryView, _, indexPath in
+            guard let self = self,
+                  let headerTitle = self.viewModel.searchQueryResultDataSource?.snapshot().sectionIdentifiers[indexPath.section].headerTitle else { return }
+            supplementaryView.configureUI(with: headerTitle)
+        }
+        
+        let dataSource = UICollectionViewDiffableDataSource<FeaturedSearchViewModel.SearchResultSection, AnyHashable>(collectionView: viewHolder.searchQueryResultCollectionView) { [weak self] (collectionView, indexPath, model) -> UICollectionViewCell? in
+            guard let self = self,
+                  let type = self.viewModel.searchQueryResultDataSource?.snapshot().sectionIdentifiers[indexPath.section] else { return nil }
+            switch type {
+            case .artistList:
+                guard let model = model as? FeaturedSubscribeArtistCellModel else { return nil }
+                return collectionView.dequeueConfiguredReusableCell(using: artistCellRegistration, for: indexPath, item: model)
+            case .performanceInfo:
+                guard let model = model as? PerformanceInfoCollectionViewCellModel else { return nil }
+                return collectionView.dequeueConfiguredReusableCell(using: performanceCellRegistration, for: indexPath, item: model)
+            }
+        }
+        
+        dataSource.supplementaryViewProvider = .init { collectionView, elementKind, indexPath in
+            return collectionView.dequeueConfiguredReusableSupplementary(using: headerRegistration, for: indexPath)
+        }
+        
+        return dataSource
+    }
+}

--- a/ShowPot/ShowPot/Presentation/Scene/Search/FeaturedSearchViewHolder.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Search/FeaturedSearchViewHolder.swift
@@ -49,7 +49,7 @@ final class FeaturedSearchViewHolder {
         $0.font = KRFont.B1_semibold
         $0.textColor = .gray400
         $0.textAlignment = .center
-        $0.setAttributedText(font: KRFont.self, string: "검색 기록이 없어요")
+        $0.setAttributedText(font: KRFont.self, string: Strings.searchEmptyTitle)
     }
     
     lazy var indicatorView = UIActivityIndicatorView().then {

--- a/ShowPot/ShowPot/Presentation/Scene/Search/FeaturedSearchViewHolder.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Search/FeaturedSearchViewHolder.swift
@@ -1,0 +1,182 @@
+//
+//  FeaturedSearchViewHolder.swift
+//  ShowPot
+//
+//  Created by 이건준 on 7/22/24.
+//
+
+import UIKit
+import SnapKit
+
+final class FeaturedSearchViewHolder {
+    
+    let backButton = UIButton().then {
+        $0.setImage(.icArrowLeft.withTintColor(.gray300), for: .normal)
+    }
+    
+    let featuredSearchTextField = FeaturedSearchTextField()
+    
+    private let recentSearchFlowLayout = LeftAlignedCollectionViewFlowLayout().then {
+        $0.minimumInteritemSpacing = 8
+        $0.minimumLineSpacing = 8
+        $0.sectionInset = .init(top: 8, left: 16, bottom: .zero, right: 16)
+        $0.scrollDirection = .vertical
+    }
+    
+    lazy var recentSearchCollectionView = UICollectionView(frame: .zero, collectionViewLayout: recentSearchFlowLayout).then {
+        $0.register(FeaturedRecentSearchCell.self)
+        $0.register(FeaturedRecentSearchHeaderView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: FeaturedRecentSearchHeaderView.identifier)
+        $0.backgroundColor = .gray700
+        $0.alwaysBounceVertical = true
+    }
+    
+    private lazy var searchResultFlowLayout = UICollectionViewCompositionalLayout { [weak self] sec, env -> NSCollectionLayoutSection? in
+        guard let self = self else { return nil }
+        let type = FeaturedSearchViewModel.SearchResultSection.allCases[sec]
+        return self.setupSearchQueryResultCollectionViewLayoutSection(type: type)
+    }
+    
+    lazy var searchQueryResultCollectionView = UICollectionView(frame: .zero, collectionViewLayout: searchResultFlowLayout).then {
+        $0.register(FeaturedSubscribeArtistCell.self)
+        $0.register(PerformanceInfoCollectionViewCell.self)
+        $0.register(FeaturedOnlyTitleHeaderView.self, of: UICollectionView.elementKindSectionHeader)
+        $0.backgroundColor = .gray700
+        $0.alwaysBounceVertical = true
+    }
+    
+    let emptyLabel = UILabel().then {
+        $0.backgroundColor = .clear
+        $0.font = KRFont.B1_semibold
+        $0.textColor = .gray400
+        $0.textAlignment = .center
+        $0.setAttributedText(font: KRFont.self, string: "검색 기록이 없어요")
+    }
+    
+    lazy var indicatorView = UIActivityIndicatorView().then {
+        $0.style = .large
+    }
+}
+
+extension FeaturedSearchViewHolder: ViewHolderType {
+    
+    func place(in view: UIView) {
+        [backButton, featuredSearchTextField, recentSearchCollectionView, searchQueryResultCollectionView, indicatorView].forEach { view.addSubview($0) }
+        recentSearchCollectionView.addSubview(emptyLabel)
+    }
+    
+    func configureConstraints(for view: UIView) {
+        
+        featuredSearchTextField.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide).offset(18)
+            $0.trailing.equalToSuperview().inset(16)
+            $0.height.equalTo(52)
+        }
+        
+        backButton.snp.makeConstraints {
+            $0.size.equalTo(36)
+            $0.leading.equalToSuperview().inset(8)
+            $0.trailing.equalTo(featuredSearchTextField.snp.leading).offset(-8)
+            $0.centerY.equalTo(featuredSearchTextField)
+        }
+        
+        recentSearchCollectionView.snp.makeConstraints {
+            $0.top.equalTo(featuredSearchTextField.snp.bottom).offset(12)
+            $0.directionalHorizontalEdges.bottom.equalToSuperview()
+        }
+        
+        emptyLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(44 + 44) // 헤더뷰 높이 + 헤더뷰~emptyLabel사이간격
+            $0.centerX.equalToSuperview()
+        }
+        
+        searchQueryResultCollectionView.snp.makeConstraints {
+            $0.top.equalTo(featuredSearchTextField.snp.bottom).offset(12)
+            $0.directionalHorizontalEdges.bottom.equalToSuperview()
+        }
+        
+        indicatorView.snp.makeConstraints {
+            $0.center.equalToSuperview()
+        }
+    }
+}
+
+extension FeaturedSearchViewHolder {
+    
+    private func setupSearchQueryResultCollectionViewLayoutSection(type: FeaturedSearchViewModel.SearchResultSection) -> NSCollectionLayoutSection {
+        switch type {
+        case .artistList:
+            return searchResultArtistLayoutSection()
+        case .performanceInfo:
+            return searchResultPerformanceLayoutSection()
+        }
+    }
+    
+    private func searchResultArtistLayoutSection() -> NSCollectionLayoutSection {
+        let groupLayoutSize = NSCollectionLayoutSize(
+            widthDimension: .absolute(100),
+            heightDimension: .absolute(129)
+        )
+        
+        let itemLayoutSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1),
+            heightDimension: .fractionalHeight(1)
+        )
+        
+        let item = NSCollectionLayoutItem(layoutSize: itemLayoutSize)
+        
+        let header = NSCollectionLayoutBoundarySupplementaryItem(
+            layoutSize: .init(
+                widthDimension: .fractionalWidth(1),
+                heightDimension: .absolute(44)
+            ),
+            elementKind: UICollectionView.elementKindSectionHeader,
+            alignment: .top
+        )
+        
+        let group = NSCollectionLayoutGroup.horizontal(
+            layoutSize: groupLayoutSize,
+            subitems: [item]
+        )
+        
+        let section = NSCollectionLayoutSection(group: group)
+        section.contentInsets = .init(top: 14, leading: 16, bottom: 36, trailing: 16)
+        section.boundarySupplementaryItems = [header]
+        section.orthogonalScrollingBehavior = .continuous
+        section.interGroupSpacing = 12
+        return section
+    }
+    
+    private func searchResultPerformanceLayoutSection() -> NSCollectionLayoutSection {
+        let groupLayoutSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1),
+            heightDimension: .absolute(80)
+        )
+        
+        let itemLayoutSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1),
+            heightDimension: .fractionalHeight(1)
+        )
+        
+        let item = NSCollectionLayoutItem(layoutSize: itemLayoutSize)
+        
+        let header = NSCollectionLayoutBoundarySupplementaryItem(
+            layoutSize: .init(
+                widthDimension: .fractionalWidth(1),
+                heightDimension: .absolute(44)
+            ),
+            elementKind: UICollectionView.elementKindSectionHeader,
+            alignment: .top
+        )
+        
+        let group = NSCollectionLayoutGroup.vertical(
+            layoutSize: groupLayoutSize,
+            subitems: [item]
+        )
+        
+        let section = NSCollectionLayoutSection(group: group)
+        section.contentInsets = .init(top: 6, leading: 16, bottom: .zero, trailing: 16)
+        section.boundarySupplementaryItems = [header]
+        section.interGroupSpacing = 16
+        return section
+    }
+}

--- a/ShowPot/ShowPot/Presentation/Scene/Search/FeaturedSearchViewHolder.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Search/FeaturedSearchViewHolder.swift
@@ -25,7 +25,7 @@ final class FeaturedSearchViewHolder {
     
     lazy var recentSearchCollectionView = UICollectionView(frame: .zero, collectionViewLayout: recentSearchFlowLayout).then {
         $0.register(FeaturedRecentSearchCell.self)
-        $0.register(FeaturedRecentSearchHeaderView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: FeaturedRecentSearchHeaderView.identifier)
+        $0.register(FeaturedRecentSearchHeaderView.self, of: UICollectionView.elementKindSectionHeader)
         $0.backgroundColor = .gray700
         $0.alwaysBounceVertical = true
     }
@@ -33,10 +33,10 @@ final class FeaturedSearchViewHolder {
     private lazy var searchResultFlowLayout = UICollectionViewCompositionalLayout { [weak self] sec, env -> NSCollectionLayoutSection? in
         guard let self = self else { return nil }
         let type = FeaturedSearchViewModel.SearchResultSection.allCases[sec]
-        return self.setupSearchQueryResultCollectionViewLayoutSection(type: type)
+        return self.setupSearchKeywordResultCollectionViewLayoutSection(type: type)
     }
     
-    lazy var searchQueryResultCollectionView = UICollectionView(frame: .zero, collectionViewLayout: searchResultFlowLayout).then {
+    lazy var searchKeywordResultCollectionView = UICollectionView(frame: .zero, collectionViewLayout: searchResultFlowLayout).then {
         $0.register(FeaturedSubscribeArtistCell.self)
         $0.register(PerformanceInfoCollectionViewCell.self)
         $0.register(FeaturedOnlyTitleHeaderView.self, of: UICollectionView.elementKindSectionHeader)
@@ -44,12 +44,10 @@ final class FeaturedSearchViewHolder {
         $0.alwaysBounceVertical = true
     }
     
-    let emptyLabel = UILabel().then {
+    let emptyLabel = SPLabel(KRFont.B1_semibold, alignment: .center).then {
         $0.backgroundColor = .clear
-        $0.font = KRFont.B1_semibold
         $0.textColor = .gray400
-        $0.textAlignment = .center
-        $0.setAttributedText(font: KRFont.self, string: Strings.searchEmptyTitle)
+        $0.setText(Strings.searchEmptyTitle)
     }
     
     lazy var indicatorView = UIActivityIndicatorView().then {
@@ -60,7 +58,7 @@ final class FeaturedSearchViewHolder {
 extension FeaturedSearchViewHolder: ViewHolderType {
     
     func place(in view: UIView) {
-        [backButton, featuredSearchTextField, recentSearchCollectionView, searchQueryResultCollectionView, indicatorView].forEach { view.addSubview($0) }
+        [backButton, featuredSearchTextField, recentSearchCollectionView, searchKeywordResultCollectionView, indicatorView].forEach { view.addSubview($0) }
         recentSearchCollectionView.addSubview(emptyLabel)
     }
     
@@ -89,7 +87,7 @@ extension FeaturedSearchViewHolder: ViewHolderType {
             $0.centerX.equalToSuperview()
         }
         
-        searchQueryResultCollectionView.snp.makeConstraints {
+        searchKeywordResultCollectionView.snp.makeConstraints {
             $0.top.equalTo(featuredSearchTextField.snp.bottom).offset(12)
             $0.directionalHorizontalEdges.bottom.equalToSuperview()
         }
@@ -102,11 +100,11 @@ extension FeaturedSearchViewHolder: ViewHolderType {
 
 extension FeaturedSearchViewHolder {
     
-    private func setupSearchQueryResultCollectionViewLayoutSection(type: FeaturedSearchViewModel.SearchResultSection) -> NSCollectionLayoutSection {
+    private func setupSearchKeywordResultCollectionViewLayoutSection(type: FeaturedSearchViewModel.SearchResultSection) -> NSCollectionLayoutSection {
         switch type {
-        case .artistList:
+        case .artist:
             return searchResultArtistLayoutSection()
-        case .performanceInfo:
+        case .performance:
             return searchResultPerformanceLayoutSection()
         }
     }

--- a/ShowPot/ShowPot/Presentation/Scene/Search/FeaturedSearchViewModel.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Search/FeaturedSearchViewModel.swift
@@ -15,45 +15,42 @@ final class FeaturedSearchViewModel: ViewModelType {
     private let disposeBag = DisposeBag()
     var coordinator: FeaturedSearchCoordinator
     
-    private var recentSearchQueryList: [String] {
-        if let recentSearchQueryList: [String] = UserDefaultsManager.shared.get(for: .recentSearchQueryList) {
-            return recentSearchQueryList
-        }
-        return []
+    private var recentSearchKeywordList: [String] {
+        UserDefaultsManager.shared.get(for: .recentSearchKeywordList) ?? []
     }
     
     /// 현재 가장 상단에 보이는 화면
-    private var currentSearchScreen: CurrentSearchScreen = .recentSearchList
+    private var currentSearchScreen: CurrentSearchScreen = .recentSearch
     
     /// 최근 검색어 최대 갯수
     private let maxSearchCount = 7
     
-    private let recentSearchListRelay = BehaviorRelay<[String]>(value: UserDefaultsManager.shared.get(for: .recentSearchQueryList) ?? [])
+    private lazy var recentSearchListRelay = BehaviorRelay<[String]>(value: recentSearchKeywordList)
     private let performanceResultListRelay = BehaviorRelay<[PerformanceInfoCollectionViewCellModel]>(value: [])
     private let artistResultListRelay = BehaviorRelay<[FeaturedSubscribeArtistCellModel]>(value: [])
     private let isLoadingRelay = BehaviorRelay<Bool>(value: false)
     
-    var recentSearchQueryDataSource: RecentSearchQueryDataSource?
-    var searchQueryResultDataSource: SearchQueryResultDataSource?
+    var recentSearchKeywordDataSource: RecentSearchKeywordDataSource?
+    var searchKeywordResultDataSource: SearchKeywordResultDataSource?
     
     init(coordinator: FeaturedSearchCoordinator) {
         self.coordinator = coordinator
     }
     
     struct Input {
-        let requestInitialSearchQueryData: Observable<Void>
+        let initialSearchKeyword: Observable<Void>
         let didTappedBackButton: Observable<Void>
         let didTappedRemoveAllButton: Observable<Void>
-        let didTappedRecentSearchQuery: Observable<IndexPath>
-        let didTappedRecentSearchQueryXButton: Observable<String>
+        let didTappedRecentSearchKeyword: Observable<IndexPath>
+        let didTappedRemoveKeywordButton: Observable<String>
         let didTappedReturnKey: Observable<String>
-        let searchQueryTextField: ControlProperty<String>
-        let didTappedSearchTextFieldXButton: Observable<Void>
+        let searchKeyword: Observable<String>
+        let didTappedSearchFieldRemoveAllButton: Observable<Void>
         let didTappedSearchResultCell: Observable<IndexPath>
     }
     
     struct Output {
-        let isRecentSearchQueryListEmpty: Driver<Bool>
+        let isRecentSearchKeywordEmpty: Driver<Bool>
         let isSearchResultEmpty: Driver<Bool>
         let isLoading: Driver<Bool>
     }
@@ -62,31 +59,36 @@ final class FeaturedSearchViewModel: ViewModelType {
         
         input.didTappedSearchResultCell
             .subscribe(with: self) { owner, indexPath in
-                guard let dataSource = owner.searchQueryResultDataSource else { return }
-                var snapshot = dataSource.snapshot()
-                let sectionIdentifier = snapshot.sectionIdentifiers[indexPath.section]
+                guard let dataSource = owner.searchKeywordResultDataSource else { return }
+                let sectionIdentifier = dataSource.snapshot().sectionIdentifiers[indexPath.section]
                 
-                switch sectionIdentifier {
-                case .artistList:
+                switch sectionIdentifier { // FIXME: - 추후 구독 API 성공 및 실패 시 다음 동작 구현 필요
+                case .artist:
                     var artistModel = owner.artistResultListRelay.value
-                    guard artistModel[indexPath.row].state == .availableSubscription else { return }
-                    artistModel[indexPath.row].state = .selected
+                    if artistModel[indexPath.row].state == .availableSubscription {
+                        LogHelper.debug("아티스트 구독선택\n모델: \(artistModel[indexPath.row])")
+                        artistModel[indexPath.row].state = .selected
+                    } else if artistModel[indexPath.row].state == .selected {
+                        LogHelper.debug("아티스트 구독취소선택\n모델: \(artistModel[indexPath.row])")
+                        artistModel[indexPath.row].state = .availableSubscription
+                    }
                     owner.artistResultListRelay.accept(artistModel)
                     owner.updateSearchResultDataSource()
-                case .performanceInfo:
-                    LogHelper.debug("검색결과 공연정보 선택")
+                case .performance:
+                    var performanceModel = owner.performanceResultListRelay.value
+                    LogHelper.debug("공연정보 선택\n모델: \(performanceModel[indexPath.row])")
                 }
             }
             .disposed(by: disposeBag)
         
-        input.didTappedRecentSearchQueryXButton
-            .subscribe(with: self) { owner, query in
-                owner.remove(query: query)
+        input.didTappedRemoveKeywordButton
+            .subscribe(with: self) { owner, keyword in
+                owner.remove(keyword: keyword)
                 owner.updateRecentSearchDataSource()
             }
             .disposed(by: disposeBag)
         
-        input.requestInitialSearchQueryData
+        input.initialSearchKeyword
             .subscribe(with: self) { owner, _ in
                 owner.updateRecentSearchDataSource()
             }
@@ -105,33 +107,27 @@ final class FeaturedSearchViewModel: ViewModelType {
             }
             .disposed(by: disposeBag)
         
-        input.didTappedReturnKey
-            .subscribe(with: self) { owner, searchQuery in
-                owner.handleSearch(query: searchQuery)
-            }
-            .disposed(by: disposeBag)
+        Observable.merge(
+            input.didTappedReturnKey,
+            input.didTappedRecentSearchKeyword
+                .withUnretained(self)
+                .map { $0.0.findSearchKeyword(indexPath: $0.1) }
+        )
+        .subscribe(with: self) { owner, searchKeyword in
+            owner.handleSearch(keyword: searchKeyword)
+        }
+        .disposed(by: disposeBag)
         
-        input.didTappedRecentSearchQuery
-            .subscribe(with: self) { owner, indexPath in
-                let query = owner.findSearchQuery(indexPath: indexPath)
-                owner.handleSearch(query: query)
-            }
-            .disposed(by: disposeBag)
+        Observable.merge(
+            input.didTappedSearchFieldRemoveAllButton,
+            input.searchKeyword.filter { $0.isEmpty }.map { _ in Void() }
+        )
+        .subscribe(with: self) { owner, _ in
+            owner.clearSearchResults()
+        }
+        .disposed(by: disposeBag)
         
-        input.didTappedSearchTextFieldXButton
-            .subscribe(with: self) { owner, _ in
-                owner.clearSearchResults()
-            }
-            .disposed(by: disposeBag)
-        
-        input.searchQueryTextField
-            .filter { $0.isEmpty }
-            .subscribe(with: self) { owner, isEmpty in
-                owner.clearSearchResults()
-            }
-            .disposed(by: disposeBag)
-        
-        let isRecentSearchQueryListEmpty = recentSearchListRelay
+        let isRecentSearchKeywordEmpty = recentSearchListRelay
             .map { $0.isEmpty }
             .asDriver(onErrorDriveWith: .empty())
         
@@ -145,7 +141,7 @@ final class FeaturedSearchViewModel: ViewModelType {
         let isLoading = isLoadingRelay.asDriver()
         
         return Output(
-            isRecentSearchQueryListEmpty: isRecentSearchQueryListEmpty,
+            isRecentSearchKeywordEmpty: isRecentSearchKeywordEmpty,
             isSearchResultEmpty: isSearchResultEmpty,
             isLoading: isLoading
         )
@@ -155,40 +151,42 @@ final class FeaturedSearchViewModel: ViewModelType {
 extension FeaturedSearchViewModel {
     
     /// 검색쿼리를 이용해 검색 API를 호출하는 함수
-    private func fetchSearchResult(searchQuery: String) {
+    private func fetchSearchResult(keyword: String) {
         isLoadingRelay.accept(true)
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) { // FIXME: - 추후 MockData수정 및 asyncAfter 코드 삭제
             
             self.artistResultListRelay.accept([
                 .init(state: .availableSubscription, artistImageURL: URL(string: "https://storage3.ilyo.co.kr/contents/article/images/2022/1013/1665663228269667.jpg"), artistName: "High Flying BirdHigh Flying BirdHigh Flying BirdHigh Flying BirdHigh Flying Bird"),
-                .init(state: .availableSubscription, artistImageURL: URL(string: "https://storage3.ilyo.co.kr/contents/article/images/2022/1013/1665663228269667.jpg"), artistName: "High Flying BirdHigh Flying BirdHigh Flying BirdHigh Flying BirdHigh Flying Bird"),
-                .init(state: .availableSubscription, artistImageURL: URL(string: "https://storage3.ilyo.co.kr/contents/article/images/2022/1013/1665663228269667.jpg"), artistName: "High Flying BirdHigh Flying BirdHigh Flying BirdHigh Flying BirdHigh Flying Bird"),
-                .init(state: .availableSubscription, artistImageURL: URL(string: "https://storage3.ilyo.co.kr/contents/article/images/2022/1013/1665663228269667.jpg"), artistName: "High Flying BirdHigh Flying BirdHigh Flying BirdHigh Flying BirdHigh Flying Bird"),
-                .init(state: .availableSubscription, artistImageURL: URL(string: "https://storage3.ilyo.co.kr/contents/article/images/2022/1013/1665663228269667.jpg"), artistName: "High Flying BirdHigh Flying BirdHigh Flying BirdHigh Flying BirdHigh Flying Bird"),
-                .init(state: .availableSubscription, artistImageURL: URL(string: "https://storage3.ilyo.co.kr/contents/article/images/2022/1013/1665663228269667.jpg"), artistName: "High Flying BirdHigh Flying BirdHigh Flying BirdHigh Flying BirdHigh Flying Bird"),
-                .init(state: .availableSubscription, artistImageURL: URL(string: "https://storage3.ilyo.co.kr/contents/article/images/2022/1013/1665663228269667.jpg"), artistName: "High Flying BirdHigh Flying BirdHigh Flying BirdHigh Flying BirdHigh Flying Bird"),
-                .init(state: .availableSubscription, artistImageURL: URL(string: "https://storage3.ilyo.co.kr/contents/article/images/2022/1013/1665663228269667.jpg"), artistName: "High Flying BirdHigh Flying BirdHigh Flying BirdHigh Flying BirdHigh Flying Bird")
+                .init(state: .availableSubscription, artistImageURL: URL(string: "https://i.imgur.com/KsEXGAZ.jpg"), artistName: "Marilia Mendonca"),
+                .init(state: .availableSubscription, artistImageURL: URL(string: "https://cdn.mhns.co.kr/news/photo/201901/157199_206779_07.jpg"), artistName: "The Chainsmokers"),
+                .init(state: .availableSubscription, artistImageURL: URL(string: "https://t3.daumcdn.net/thumb/R720x0/?fname=http://t1.daumcdn.net/brunch/service/user/2fG8/image/sxiZQJy0MaesFjfzRRoyNWNRmhM.jpg"), artistName: "Beyonce"),
+                .init(state: .availableSubscription, artistImageURL: URL(string: "https://cdn.redian.org/news/photo/202108/155857_52695_0153.jpg"), artistName: "Adele"),
+                .init(state: .availableSubscription, artistImageURL: URL(string: "https://img1.daumcdn.net/thumb/R800x0/?scode=mtistory2&fname=https%3A%2F%2Ft1.daumcdn.net%2Fcfile%2Ftistory%2F1709EC404F290F7720"), artistName: "Imagine Dragons"),
+                .init(state: .availableSubscription, artistImageURL: URL(string: "https://mblogthumb-phinf.pstatic.net/MjAxOTEwMzBfMjM1/MDAxNTcyNDI4Mzg2NjI2.vFBBiLlc8YhPuny8BFHTYczJzoR1ObVC8ZHX2iAGye4g.BVn1BX_bMjbib22Ks-l2VCQUd70yU7o8vNBLcBhSH1gg.PNG.alvin5092/1572428385660.png?type=w800"), artistName: "Maluma"),
+                .init(state: .availableSubscription, artistImageURL: URL(string: "https://i.namu.wiki/i/jrUaXffKzxPCo876eNO8GRdQb81OBQuNV99GnN1pDlXkGcvEsyTJaEtCsWzEtjy4yVoOnPqP058LrPswAh7KQQ.webp"), artistName: "Bruno Mars")
             ])
             
             self.performanceResultListRelay.accept([
                 
-                .init(performanceImageURL: URL(string: "https://img.newspim.com/news/2023/09/21/2309210928580280.jpg"), performanceTitle: "에스파단독고연", performanceTime: "2024.12.4 (수) 오후 8시", performanceLocation: "KBS 아레나홀"),
-                .init(performanceImageURL: URL(string: "https://img.newspim.com/news/2023/09/21/2309210928580280.jpg"), performanceTitle: "에스파단독고연", performanceTime: "2024.12.4 (수) 오후 8시", performanceLocation: "KBS 아레나홀"),
-                .init(performanceImageURL: URL(string: "https://img.newspim.com/news/2023/09/21/2309210928580280.jpg"), performanceTitle: "에스파단독고연", performanceTime: "2024.12.4 (수) 오후 8시", performanceLocation: "KBS 아레나홀"),
-                .init(performanceImageURL: URL(string: "https://img.newspim.com/news/2023/09/21/2309210928580280.jpg"), performanceTitle: "에스파단독고연", performanceTime: "2024.12.4 (수) 오후 8시", performanceLocation: "KBS 아레나홀"),
-                .init(performanceImageURL: URL(string: "https://img.newspim.com/news/2023/09/21/2309210928580280.jpg"), performanceTitle: "에스파단독고연", performanceTime: "2024.12.4 (수) 오후 8시", performanceLocation: "KBS 아레나홀"),
-                .init(performanceImageURL: URL(string: "https://img.newspim.com/news/2023/09/21/2309210928580280.jpg"), performanceTitle: "에스파단독고연", performanceTime: "2024.12.4 (수) 오후 8시", performanceLocation: "KBS 아레나홀"),
-                .init(performanceImageURL: URL(string: "https://img.newspim.com/news/2023/09/21/2309210928580280.jpg"), performanceTitle: "에스파단독고연", performanceTime: "2024.12.4 (수) 오후 8시", performanceLocation: "KBS 아레나홀"),
-                .init(performanceImageURL: URL(string: "https://img.newspim.com/news/2023/09/21/2309210928580280.jpg"), performanceTitle: "에스파단독고연", performanceTime: "2024.12.4 (수) 오후 8시", performanceLocation: "KBS 아레나홀"),
-                .init(performanceImageURL: URL(string: "https://img.newspim.com/news/2023/09/21/2309210928580280.jpg"), performanceTitle: "에스파단독고연", performanceTime: "2024.12.4 (수) 오후 8시", performanceLocation: "KBS 아레나홀"),
-                .init(performanceImageURL: URL(string: "https://img.newspim.com/news/2023/09/21/2309210928580280.jpg"), performanceTitle: "에스파단독고연", performanceTime: "2024.12.4 (수) 오후 8시", performanceLocation: "KBS 아레나홀"),
-                .init(performanceImageURL: URL(string: "https://img.newspim.com/news/2023/09/21/2309210928580280.jpg"), performanceTitle: "에스파단독고연", performanceTime: "2024.12.4 (수) 오후 8시", performanceLocation: "KBS 아레나홀"),
-                .init(performanceImageURL: URL(string: "https://img.newspim.com/news/2023/09/21/2309210928580280.jpg"), performanceTitle: "에스파단독고연", performanceTime: "2024.12.4 (수) 오후 8시", performanceLocation: "KBS 아레나홀"),
-                .init(performanceImageURL: URL(string: "https://img.newspim.com/news/2023/09/21/2309210928580280.jpg"), performanceTitle: "에스파단독고연", performanceTime: "2024.12.4 (수) 오후 8시", performanceLocation: "KBS 아레나홀")
+                .init(performanceImageURL: URL(string: "https://img.newspim.com/news/2023/09/21/2309210928580280.jpg"), performanceTitle: "에스파단독고연", performanceTime: Date(timeIntervalSinceNow: 24 * 60 * 60), performanceLocation: "KBS 아레나홀"),
+                .init(performanceImageURL: URL(string: "https://image.bugsm.co.kr/essential/images/500/39/3978.jpg"), performanceTitle: "샘스미스단독공연", performanceTime: Date(timeIntervalSinceNow: 24 * 60), performanceLocation: "KBS 아레나홀"),
+                .init(performanceImageURL: URL(string: "https://img.newspim.com/news/2023/03/06/2303060940437270.jpg"), performanceTitle: "안젤리나졸리단독고연", performanceTime: Date(timeIntervalSinceNow: 24 * 60 * 60 * 60), performanceLocation: "KBS 아레나홀"),
+                .init(performanceImageURL: URL(string: "https://www.gugakpeople.com/data/gugakpeople_com/mainimages/202407/2024071636209869.jpg"), performanceTitle: "브루노마스단독고연", performanceTime: Date(timeIntervalSinceNow: 24), performanceLocation: "KBS 아레나홀"),
+                .init(performanceImageURL: URL(string: "https://img.newspim.com/news/2023/06/05/2306051642145540.jpg"), performanceTitle: "워시단독고연", performanceTime: Date(timeIntervalSinceNow: 24 * 60 * 60), performanceLocation: "KBS 아레나홀")
             ])
             self.isLoadingRelay.accept(false)
             self.updateSearchResultDataSource()
         }
+    }
+    
+    /// 특정 아티스트를 구독하는 함수
+    private func subscribeArtist() {
+        
+    }
+    
+    /// 특정 아티스트를 구독취소하는 함수
+    private func cancelSubscribeArtist() {
+        
     }
 }
 
@@ -196,52 +194,52 @@ extension FeaturedSearchViewModel {
 
 extension FeaturedSearchViewModel {
     
-    private func findSearchQuery(indexPath: IndexPath) -> String {
+    private func findSearchKeyword(indexPath: IndexPath) -> String {
         recentSearchListRelay.value[indexPath.row]
     }
     
-    private func add(query: String) {
-        var queryList = recentSearchListRelay.value
+    private func add(keyword: String) {
+        var keywordList = recentSearchListRelay.value
         
-        if queryList.contains(query) {
-            queryList.removeAll(where: { $0 == query })
-        } else if queryList.count >= maxSearchCount {
-            queryList.removeLast()
+        if keywordList.contains(keyword) {
+            keywordList.removeAll(where: { $0 == keyword })
+        } else if keywordList.count >= maxSearchCount {
+            keywordList.removeLast()
         }
         
-        queryList.insert(query, at: 0)
-        recentSearchListRelay.accept(queryList)
-        UserDefaultsManager.shared.set(queryList, for: .recentSearchQueryList)
+        keywordList.insert(keyword, at: 0)
+        recentSearchListRelay.accept(keywordList)
+        UserDefaultsManager.shared.set(keywordList, for: .recentSearchKeywordList)
     }
     
-    private func remove(query: String) {
-        var queryList = recentSearchListRelay.value
-        guard queryList.contains(query) else { return }
-        queryList.removeAll(where: { $0 == query })
-        recentSearchListRelay.accept(queryList)
-        UserDefaultsManager.shared.set(queryList, for: .recentSearchQueryList)
+    private func remove(keyword: String) {
+        var keywordList = recentSearchListRelay.value
+        guard keywordList.contains(keyword) else { return }
+        keywordList.removeAll(where: { $0 == keyword })
+        recentSearchListRelay.accept(keywordList)
+        UserDefaultsManager.shared.set(keywordList, for: .recentSearchKeywordList)
     }
     
     private func removeAll() {
         LogHelper.debug("모두삭제 버튼 클릭")
         guard !recentSearchListRelay.value.isEmpty else { return }
         recentSearchListRelay.accept([])
-        UserDefaultsManager.shared.set([], for: .recentSearchQueryList)
+        UserDefaultsManager.shared.set([], for: .recentSearchKeywordList)
     }
     
     private func handleBackButtonTap() {
-        if currentSearchScreen == .recentSearchList {
+        if currentSearchScreen == .recentSearch {
             coordinator.popViewController()
         } else {
             performanceResultListRelay.accept([])
             artistResultListRelay.accept([])
-            currentSearchScreen = .recentSearchList
+            currentSearchScreen = .recentSearch
         }
     }
     
-    private func handleSearch(query: String) {
-        add(query: query)
-        fetchSearchResult(searchQuery: query)
+    private func handleSearch(keyword: String) {
+        add(keyword: keyword)
+        fetchSearchResult(keyword: keyword)
         updateRecentSearchDataSource()
         updateSearchResultDataSource()
         currentSearchScreen = .searchResult
@@ -252,7 +250,7 @@ extension FeaturedSearchViewModel {
             performanceResultListRelay.accept([])
             artistResultListRelay.accept([])
         }
-        currentSearchScreen = .recentSearchList
+        currentSearchScreen = .recentSearch
     }
 }
 
@@ -262,24 +260,24 @@ extension FeaturedSearchViewModel {
     
     typealias RecentSearchItem = String
     typealias SearchResultItem = AnyHashable
-    typealias RecentSearchQueryDataSource = UICollectionViewDiffableDataSource<RecentSearchSection, RecentSearchItem>
-    typealias SearchQueryResultDataSource = UICollectionViewDiffableDataSource<SearchResultSection, SearchResultItem>
+    typealias RecentSearchKeywordDataSource = UICollectionViewDiffableDataSource<RecentSearchSection, RecentSearchItem>
+    typealias SearchKeywordResultDataSource = UICollectionViewDiffableDataSource<SearchResultSection, SearchResultItem>
     
     /// 최근 검색어 리스트 섹션 타입
-    enum RecentSearchSection: CaseIterable {
+    enum RecentSearchSection {
         case main
     }
     
     /// 검색 결과 섹션 타입
     enum SearchResultSection: CaseIterable {
-        case artistList
-        case performanceInfo
+        case artist
+        case performance
         
         var headerTitle: String {
             switch self {
-            case .artistList:
+            case .artist:
                 return Strings.searchArtistTitle
-            case .performanceInfo:
+            case .performance:
                 return Strings.searchPerformanceTitle
             }
         }
@@ -287,16 +285,16 @@ extension FeaturedSearchViewModel {
     
     /// 현재 최상단 검색화면
     enum CurrentSearchScreen {
-        case recentSearchList
+        case recentSearch
         case searchResult
     }
     
     private func updateRecentSearchDataSource() {
-        let queryList = recentSearchListRelay.value
+        let keywordList = recentSearchListRelay.value
         var snapshot = NSDiffableDataSourceSnapshot<RecentSearchSection, RecentSearchItem>()
         snapshot.appendSections([.main])
-        snapshot.appendItems(queryList)
-        recentSearchQueryDataSource?.apply(snapshot)
+        snapshot.appendItems(keywordList)
+        recentSearchKeywordDataSource?.apply(snapshot)
     }
     
     private func updateSearchResultDataSource() {
@@ -304,10 +302,10 @@ extension FeaturedSearchViewModel {
         let performanceResultList = performanceResultListRelay.value
         
         var snapshot = NSDiffableDataSourceSnapshot<SearchResultSection, SearchResultItem>()
-        snapshot.appendSections([.artistList, .performanceInfo])
-        snapshot.appendItems(artistResultList, toSection: .artistList)
-        snapshot.appendItems(performanceResultList, toSection: .performanceInfo)
+        snapshot.appendSections([.artist, .performance])
+        snapshot.appendItems(artistResultList, toSection: .artist)
+        snapshot.appendItems(performanceResultList, toSection: .performance)
         
-        searchQueryResultDataSource?.apply(snapshot)
+        searchKeywordResultDataSource?.apply(snapshot)
     }
 }

--- a/ShowPot/ShowPot/Presentation/Scene/Search/FeaturedSearchViewModel.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Search/FeaturedSearchViewModel.swift
@@ -278,9 +278,9 @@ extension FeaturedSearchViewModel {
         var headerTitle: String {
             switch self {
             case .artistList:
-                return "아티스트"
+                return Strings.searchArtistTitle
             case .performanceInfo:
-                return "공연 정보"
+                return Strings.searchPerformanceTitle
             }
         }
     }

--- a/ShowPot/ShowPot/Presentation/Scene/Search/FeaturedSearchViewModel.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Search/FeaturedSearchViewModel.swift
@@ -1,0 +1,306 @@
+//
+//  FeaturedSearchViewModel.swift
+//  ShowPot
+//
+//  Created by 이건준 on 7/22/24.
+//
+
+import UIKit
+
+import RxSwift
+import RxCocoa
+
+final class FeaturedSearchViewModel: ViewModelType {
+    
+    private let disposeBag = DisposeBag()
+    var coordinator: FeaturedSearchCoordinator
+    
+    /// 현재 가장 상단에 보이는 화면
+    private var currentSearchScreen: CurrentSearchScreen = .recentSearchList
+    
+    /// 최근 검색어 최대 갯수
+    private let maxSearchCount = 7
+    
+    private let recentSearchListRelay = BehaviorRelay<[String]>(value: UserDefaultsManager.shared.get(for: .recentSearchQueryList) ?? [])
+    private let performanceResultListRelay = BehaviorRelay<[PerformanceInfoCollectionViewCellModel]>(value: [])
+    private let artistResultListRelay = BehaviorRelay<[FeaturedSubscribeArtistCellModel]>(value: [])
+    private let isLoadingRelay = BehaviorRelay<Bool>(value: false)
+    
+    var recentSearchQueryDataSource: RecentSearchQueryDataSource?
+    var searchQueryResultDataSource: SearchQueryResultDataSource?
+    
+    init(coordinator: FeaturedSearchCoordinator) {
+        self.coordinator = coordinator
+    }
+    
+    struct Input {
+        let requestInitialSearchQueryData: Observable<Void>
+        let didTappedBackButton: Observable<Void>
+        let didTappedRemoveAllButton: Observable<Void>
+        let didTappedRecentSearchQuery: Observable<IndexPath>
+        let didTappedRecentSearchQueryXButton: Observable<String>
+        let didTappedReturnKey: Observable<String>
+        let searchQueryTextField: ControlProperty<String>
+        let didTappedSearchTextFieldXButton: Observable<Void>
+        let didTappedSearchResultCell: Observable<IndexPath>
+    }
+    
+    struct Output {
+        let isRecentSearchQueryListEmpty: Driver<Bool>
+        let isSearchResultEmpty: Driver<Bool>
+        let isLoading: Driver<Bool>
+    }
+    
+    func transform(input: Input) -> Output {
+        
+        input.didTappedSearchResultCell
+            .subscribe(with: self) { owner, indexPath in
+                guard let dataSource = owner.searchQueryResultDataSource else { return }
+                var snapshot = dataSource.snapshot()
+                let sectionIdentifier = snapshot.sectionIdentifiers[indexPath.section]
+                
+                switch sectionIdentifier {
+                case .artistList:
+                    var artistModel = owner.artistResultListRelay.value
+                    guard artistModel[indexPath.row].state == .availableSubscription else { return }
+                    artistModel[indexPath.row].state = .selected
+                    owner.artistResultListRelay.accept(artistModel)
+                    owner.updateSearchResultDataSource()
+                case .performanceInfo:
+                    LogHelper.debug("검색결과 공연정보 선택")
+                }
+            }
+            .disposed(by: disposeBag)
+        
+        input.didTappedRecentSearchQueryXButton
+            .subscribe(with: self) { owner, query in
+                owner.remove(query: query)
+                owner.updateRecentSearchDataSource()
+            }
+            .disposed(by: disposeBag)
+        
+        input.requestInitialSearchQueryData
+            .subscribe(with: self) { owner, _ in
+                owner.updateRecentSearchDataSource()
+            }
+            .disposed(by: disposeBag)
+        
+        input.didTappedBackButton
+            .subscribe(with: self) { owner, _ in
+                owner.handleBackButtonTap()
+            }
+            .disposed(by: disposeBag)
+        
+        input.didTappedRemoveAllButton
+            .subscribe(with: self) { owner, _ in
+                owner.removeAll()
+                owner.updateRecentSearchDataSource()
+            }
+            .disposed(by: disposeBag)
+        
+        input.didTappedReturnKey
+            .subscribe(with: self) { owner, searchQuery in
+                owner.handleSearch(query: searchQuery)
+            }
+            .disposed(by: disposeBag)
+        
+        input.didTappedRecentSearchQuery
+            .subscribe(with: self) { owner, indexPath in
+                let query = owner.findSearchQuery(indexPath: indexPath)
+                owner.handleSearch(query: query)
+            }
+            .disposed(by: disposeBag)
+        
+        input.didTappedSearchTextFieldXButton
+            .subscribe(with: self) { owner, _ in
+                owner.clearSearchResults()
+            }
+            .disposed(by: disposeBag)
+        
+        input.searchQueryTextField
+            .filter { $0.isEmpty }
+            .subscribe(with: self) { owner, isEmpty in
+                owner.clearSearchResults()
+            }
+            .disposed(by: disposeBag)
+        
+        let isRecentSearchQueryListEmpty = recentSearchListRelay
+            .map { $0.isEmpty }
+            .asDriver(onErrorDriveWith: .empty())
+        
+        let isSearchResultEmpty = Observable.combineLatest(
+            artistResultListRelay,
+            performanceResultListRelay
+        )
+            .map { $0.0.isEmpty && $0.1.isEmpty }
+            .asDriver(onErrorDriveWith: .empty())
+        
+        let isLoading = isLoadingRelay.asDriver()
+        
+        return Output(
+            isRecentSearchQueryListEmpty: isRecentSearchQueryListEmpty,
+            isSearchResultEmpty: isSearchResultEmpty,
+            isLoading: isLoading
+        )
+    }
+}
+
+extension FeaturedSearchViewModel {
+    
+    /// 검색쿼리를 이용해 검색 API를 호출하는 함수
+    private func fetchSearchResult(searchQuery: String) {
+        isLoadingRelay.accept(true)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) { // FIXME: - 추후 MockData수정 및 asyncAfter 코드 삭제
+            
+            self.artistResultListRelay.accept([
+                .init(state: .availableSubscription, artistImageURL: URL(string: "https://storage3.ilyo.co.kr/contents/article/images/2022/1013/1665663228269667.jpg"), artistName: "High Flying BirdHigh Flying BirdHigh Flying BirdHigh Flying BirdHigh Flying Bird"),
+                .init(state: .availableSubscription, artistImageURL: URL(string: "https://storage3.ilyo.co.kr/contents/article/images/2022/1013/1665663228269667.jpg"), artistName: "High Flying BirdHigh Flying BirdHigh Flying BirdHigh Flying BirdHigh Flying Bird"),
+                .init(state: .availableSubscription, artistImageURL: URL(string: "https://storage3.ilyo.co.kr/contents/article/images/2022/1013/1665663228269667.jpg"), artistName: "High Flying BirdHigh Flying BirdHigh Flying BirdHigh Flying BirdHigh Flying Bird"),
+                .init(state: .availableSubscription, artistImageURL: URL(string: "https://storage3.ilyo.co.kr/contents/article/images/2022/1013/1665663228269667.jpg"), artistName: "High Flying BirdHigh Flying BirdHigh Flying BirdHigh Flying BirdHigh Flying Bird"),
+                .init(state: .availableSubscription, artistImageURL: URL(string: "https://storage3.ilyo.co.kr/contents/article/images/2022/1013/1665663228269667.jpg"), artistName: "High Flying BirdHigh Flying BirdHigh Flying BirdHigh Flying BirdHigh Flying Bird"),
+                .init(state: .availableSubscription, artistImageURL: URL(string: "https://storage3.ilyo.co.kr/contents/article/images/2022/1013/1665663228269667.jpg"), artistName: "High Flying BirdHigh Flying BirdHigh Flying BirdHigh Flying BirdHigh Flying Bird"),
+                .init(state: .availableSubscription, artistImageURL: URL(string: "https://storage3.ilyo.co.kr/contents/article/images/2022/1013/1665663228269667.jpg"), artistName: "High Flying BirdHigh Flying BirdHigh Flying BirdHigh Flying BirdHigh Flying Bird"),
+                .init(state: .availableSubscription, artistImageURL: URL(string: "https://storage3.ilyo.co.kr/contents/article/images/2022/1013/1665663228269667.jpg"), artistName: "High Flying BirdHigh Flying BirdHigh Flying BirdHigh Flying BirdHigh Flying Bird")
+            ])
+            
+            self.performanceResultListRelay.accept([
+                
+                .init(performanceImageURL: URL(string: "https://img.newspim.com/news/2023/09/21/2309210928580280.jpg"), performanceTitle: "에스파단독고연", performanceTime: "2024.12.4 (수) 오후 8시", performanceLocation: "KBS 아레나홀"),
+                .init(performanceImageURL: URL(string: "https://img.newspim.com/news/2023/09/21/2309210928580280.jpg"), performanceTitle: "에스파단독고연", performanceTime: "2024.12.4 (수) 오후 8시", performanceLocation: "KBS 아레나홀"),
+                .init(performanceImageURL: URL(string: "https://img.newspim.com/news/2023/09/21/2309210928580280.jpg"), performanceTitle: "에스파단독고연", performanceTime: "2024.12.4 (수) 오후 8시", performanceLocation: "KBS 아레나홀"),
+                .init(performanceImageURL: URL(string: "https://img.newspim.com/news/2023/09/21/2309210928580280.jpg"), performanceTitle: "에스파단독고연", performanceTime: "2024.12.4 (수) 오후 8시", performanceLocation: "KBS 아레나홀"),
+                .init(performanceImageURL: URL(string: "https://img.newspim.com/news/2023/09/21/2309210928580280.jpg"), performanceTitle: "에스파단독고연", performanceTime: "2024.12.4 (수) 오후 8시", performanceLocation: "KBS 아레나홀"),
+                .init(performanceImageURL: URL(string: "https://img.newspim.com/news/2023/09/21/2309210928580280.jpg"), performanceTitle: "에스파단독고연", performanceTime: "2024.12.4 (수) 오후 8시", performanceLocation: "KBS 아레나홀"),
+                .init(performanceImageURL: URL(string: "https://img.newspim.com/news/2023/09/21/2309210928580280.jpg"), performanceTitle: "에스파단독고연", performanceTime: "2024.12.4 (수) 오후 8시", performanceLocation: "KBS 아레나홀"),
+                .init(performanceImageURL: URL(string: "https://img.newspim.com/news/2023/09/21/2309210928580280.jpg"), performanceTitle: "에스파단독고연", performanceTime: "2024.12.4 (수) 오후 8시", performanceLocation: "KBS 아레나홀"),
+                .init(performanceImageURL: URL(string: "https://img.newspim.com/news/2023/09/21/2309210928580280.jpg"), performanceTitle: "에스파단독고연", performanceTime: "2024.12.4 (수) 오후 8시", performanceLocation: "KBS 아레나홀"),
+                .init(performanceImageURL: URL(string: "https://img.newspim.com/news/2023/09/21/2309210928580280.jpg"), performanceTitle: "에스파단독고연", performanceTime: "2024.12.4 (수) 오후 8시", performanceLocation: "KBS 아레나홀"),
+                .init(performanceImageURL: URL(string: "https://img.newspim.com/news/2023/09/21/2309210928580280.jpg"), performanceTitle: "에스파단독고연", performanceTime: "2024.12.4 (수) 오후 8시", performanceLocation: "KBS 아레나홀"),
+                .init(performanceImageURL: URL(string: "https://img.newspim.com/news/2023/09/21/2309210928580280.jpg"), performanceTitle: "에스파단독고연", performanceTime: "2024.12.4 (수) 오후 8시", performanceLocation: "KBS 아레나홀"),
+                .init(performanceImageURL: URL(string: "https://img.newspim.com/news/2023/09/21/2309210928580280.jpg"), performanceTitle: "에스파단독고연", performanceTime: "2024.12.4 (수) 오후 8시", performanceLocation: "KBS 아레나홀")
+            ])
+            self.isLoadingRelay.accept(false)
+            self.updateSearchResultDataSource()
+        }
+    }
+}
+
+// MARK: - FeaturedSearch Helper
+
+extension FeaturedSearchViewModel {
+    
+    private func findSearchQuery(indexPath: IndexPath) -> String {
+        recentSearchListRelay.value[indexPath.row]
+    }
+    
+    private func add(query: String) {
+        var queryList = recentSearchListRelay.value
+        
+        if queryList.contains(query) {
+            queryList.removeAll(where: { $0 == query })
+        } else if queryList.count >= maxSearchCount {
+            queryList.removeLast()
+        }
+        
+        queryList.insert(query, at: 0)
+        recentSearchListRelay.accept(queryList)
+        UserDefaultsManager.shared.set(queryList, for: .recentSearchQueryList)
+    }
+    
+    private func remove(query: String) {
+        var queryList = recentSearchListRelay.value
+        guard queryList.contains(query) else { return }
+        queryList.removeAll(where: { $0 == query })
+        recentSearchListRelay.accept(queryList)
+        UserDefaultsManager.shared.set(queryList, for: .recentSearchQueryList)
+    }
+    
+    private func removeAll() {
+        LogHelper.debug("모두삭제 버튼 클릭")
+        guard !recentSearchListRelay.value.isEmpty else { return }
+        recentSearchListRelay.accept([])
+        UserDefaultsManager.shared.set([], for: .recentSearchQueryList)
+    }
+    
+    private func handleBackButtonTap() {
+        if currentSearchScreen == .recentSearchList {
+            coordinator.popViewController()
+        } else {
+            performanceResultListRelay.accept([])
+            artistResultListRelay.accept([])
+            currentSearchScreen = .recentSearchList
+        }
+    }
+    
+    private func handleSearch(query: String) {
+        add(query: query)
+        fetchSearchResult(searchQuery: query)
+        updateRecentSearchDataSource()
+        updateSearchResultDataSource()
+        currentSearchScreen = .searchResult
+    }
+    
+    private func clearSearchResults() {
+        if !performanceResultListRelay.value.isEmpty || !artistResultListRelay.value.isEmpty {
+            performanceResultListRelay.accept([])
+            artistResultListRelay.accept([])
+        }
+        currentSearchScreen = .recentSearchList
+    }
+}
+
+// MARK: - For NSDiffableDataSource
+
+extension FeaturedSearchViewModel {
+    
+    typealias RecentSearchItem = String
+    typealias SearchResultItem = AnyHashable
+    typealias RecentSearchQueryDataSource = UICollectionViewDiffableDataSource<RecentSearchSection, RecentSearchItem>
+    typealias SearchQueryResultDataSource = UICollectionViewDiffableDataSource<SearchResultSection, SearchResultItem>
+    
+    /// 최근 검색어 리스트 섹션 타입
+    enum RecentSearchSection: CaseIterable {
+        case main
+    }
+    
+    /// 검색 결과 섹션 타입
+    enum SearchResultSection: CaseIterable {
+        case artistList
+        case performanceInfo
+        
+        var headerTitle: String {
+            switch self {
+            case .artistList:
+                return "아티스트"
+            case .performanceInfo:
+                return "공연 정보"
+            }
+        }
+    }
+    
+    /// 현재 최상단 검색화면
+    enum CurrentSearchScreen {
+        case recentSearchList
+        case searchResult
+    }
+    
+    private func updateRecentSearchDataSource() {
+        let queryList = recentSearchListRelay.value
+        var snapshot = NSDiffableDataSourceSnapshot<RecentSearchSection, RecentSearchItem>()
+        snapshot.appendSections([.main])
+        snapshot.appendItems(queryList)
+        recentSearchQueryDataSource?.apply(snapshot)
+    }
+    
+    private func updateSearchResultDataSource() {
+        let artistResultList = artistResultListRelay.value
+        let performanceResultList = performanceResultListRelay.value
+        
+        var snapshot = NSDiffableDataSourceSnapshot<SearchResultSection, SearchResultItem>()
+        snapshot.appendSections([.artistList, .performanceInfo])
+        snapshot.appendItems(artistResultList, toSection: .artistList)
+        snapshot.appendItems(performanceResultList, toSection: .performanceInfo)
+        
+        searchQueryResultDataSource?.apply(snapshot)
+    }
+}

--- a/ShowPot/ShowPot/Presentation/Scene/Search/FeaturedSearchViewModel.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Search/FeaturedSearchViewModel.swift
@@ -15,6 +15,13 @@ final class FeaturedSearchViewModel: ViewModelType {
     private let disposeBag = DisposeBag()
     var coordinator: FeaturedSearchCoordinator
     
+    private var recentSearchQueryList: [String] {
+        if let recentSearchQueryList: [String] = UserDefaultsManager.shared.get(for: .recentSearchQueryList) {
+            return recentSearchQueryList
+        }
+        return []
+    }
+    
     /// 현재 가장 상단에 보이는 화면
     private var currentSearchScreen: CurrentSearchScreen = .recentSearchList
     

--- a/ShowPot/ShowPot/Presentation/Scene/Tab/Featured/CustomView/FeaturedSubscribeArtistCell.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Tab/Featured/CustomView/FeaturedSubscribeArtistCell.swift
@@ -64,6 +64,7 @@ final class FeaturedSubscribeArtistCell: UICollectionViewCell, ReusableCell {
         super.prepareForReuse()
         artistImageView.image = nil
         artistNameLabel.text = nil
+        state = .availableSubscription
     }
     
     private func setupLayouts() {

--- a/ShowPot/ShowPot/Presentation/Scene/Tab/Featured/CustomView/FeaturedSubscribeArtistCell.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Tab/Featured/CustomView/FeaturedSubscribeArtistCell.swift
@@ -132,10 +132,16 @@ extension FeaturedSubscribeArtistCell {
 
 // MARK: Data Configuration
 
-struct FeaturedSubscribeArtistCellModel {
+struct FeaturedSubscribeArtistCellModel: Hashable {
     var state: FeaturedSubscribeArtistCellState
     let artistImageURL: URL?
     let artistName: String
+    
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(identifier)
+    }
+    
+    private let identifier = UUID() // TODO: - 추후 아티스트 정보에 대한 아이디로 대체
 }
 
 extension FeaturedSubscribeArtistCell {

--- a/ShowPot/ShowPot/Presentation/Scene/Tab/Featured/CustomView/FeaturedSubscribeArtistCell.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Tab/Featured/CustomView/FeaturedSubscribeArtistCell.swift
@@ -91,13 +91,13 @@ extension FeaturedSubscribeArtistCell {
             return
         case .selected:
             setupSubscribeArtistCell(
-                image: .icCheck.withTintColor(.white),
+                image: .icCheck.withTintColor(.gray000),
                 alpha: 0.7,
                 alphaBackgroundColor: .mainOrange
             )
         case .availableSubscription:
             setupSubscribeArtistCell(
-                image: .icAlarmPlus.withTintColor(.white),
+                image: .icAlarmPlus.withTintColor(.gray000),
                 alpha: 0.5,
                 alphaBackgroundColor: .gray700
             )

--- a/ShowPot/ShowPot/Resource/Localizable/Localizable.strings
+++ b/ShowPot/ShowPot/Resource/Localizable/Localizable.strings
@@ -42,7 +42,7 @@
 // 검색 화면
 "search_artist_title" = "아티스트";
 "search_performance_title" = "공연 정보";
-"search_query_title" = "최근검색어";
-"search_query_button_title" = "모두삭제";
+"search_keyword_title" = "최근검색어";
+"search_keyword_button_title" = "모두삭제";
 "search_empty_title" = "검색 기록이 없어요";
 

--- a/ShowPot/ShowPot/Resource/Localizable/Localizable.strings
+++ b/ShowPot/ShowPot/Resource/Localizable/Localizable.strings
@@ -38,3 +38,11 @@
 "home_searchbar_placeholder" = "관심 있는 공연과 가수를 검색해보세요";
 "home_ticketing_performance_title" = "티켓팅이 얼마 남지 않은 공연";
 "home_ticketing_performance_buttonTitle" = "전체공연 보러가기";
+
+// 검색 화면
+"search_artist_title" = "아티스트";
+"search_performance_title" = "공연 정보";
+"search_query_title" = "최근검색어";
+"search_query_button_title" = "모두삭제";
+"search_empty_title" = "검색 기록이 없어요";
+

--- a/ShowPot/ShowPot/Resource/Localizable/Strings+Generated.swift
+++ b/ShowPot/ShowPot/Resource/Localizable/Strings+Generated.swift
@@ -37,22 +37,22 @@ public enum Strings {
   public static let onboardingTitle1 = Strings.tr("Localizable", "onboarding_title_1", fallback: "티켓팅 알림받기")
   /// 장르/아티스트 구독하기
   public static let onboardingTitle2 = Strings.tr("Localizable", "onboarding_title_2", fallback: "장르/아티스트 구독하기")
+  /// 아티스트
+  public static let searchArtistTitle = Strings.tr("Localizable", "search_artist_title", fallback: "아티스트")
+  /// 검색 기록이 없어요
+  public static let searchEmptyTitle = Strings.tr("Localizable", "search_empty_title", fallback: "검색 기록이 없어요")
+  /// 모두삭제
+  public static let searchKeywordButtonTitle = Strings.tr("Localizable", "search_keyword_button_title", fallback: "모두삭제")
+  /// 최근검색어
+  public static let searchKeywordTitle = Strings.tr("Localizable", "search_keyword_title", fallback: "최근검색어")
+  /// 공연 정보
+  public static let searchPerformanceTitle = Strings.tr("Localizable", "search_performance_title", fallback: "공연 정보")
   /// 보러가기
   public static let snackbarActionTitle = Strings.tr("Localizable", "snackbar_action_title", fallback: "보러가기")
   /// 알림 설정이 완료되었습니다
   public static let snackbarDescriptionAlarm = Strings.tr("Localizable", "snackbar_description_alarm", fallback: "알림 설정이 완료되었습니다")
   /// Common
   public static let snackbarDescriptionSubscribe = Strings.tr("Localizable", "snackbar_description_subscribe", fallback: "구독 설정이 완료되었습니다")
-  /// 아티스트
-  public static let searchArtistTitle = Strings.tr("Localizable", "search_artist_title", fallback: "아티스트")
-  /// 검색 기록이 없어요
-  public static let searchEmptyTitle = Strings.tr("Localizable", "search_empty_title", fallback: "검색 기록이 없어요")
-  /// 공연 정보
-  public static let searchPerformanceTitle = Strings.tr("Localizable", "search_performance_title", fallback: "공연 정보")
-  /// 모두삭제
-  public static let searchQueryButtonTitle = Strings.tr("Localizable", "search_query_button_title", fallback: "모두삭제")
-  /// 최근검색어
-  public static let searchQueryTitle = Strings.tr("Localizable", "search_query_title", fallback: "최근검색어")
   /// Apple로 시작하기
   public static let socialLoginAppleButton = Strings.tr("Localizable", "socialLogin_apple_button", fallback: "Apple로 시작하기")
   /// 잊지않고 내한공연 즐기러가요

--- a/ShowPot/ShowPot/Resource/Localizable/Strings+Generated.swift
+++ b/ShowPot/ShowPot/Resource/Localizable/Strings+Generated.swift
@@ -43,6 +43,16 @@ public enum Strings {
   public static let snackbarDescriptionAlarm = Strings.tr("Localizable", "snackbar_description_alarm", fallback: "알림 설정이 완료되었습니다")
   /// Common
   public static let snackbarDescriptionSubscribe = Strings.tr("Localizable", "snackbar_description_subscribe", fallback: "구독 설정이 완료되었습니다")
+  /// 아티스트
+  public static let searchArtistTitle = Strings.tr("Localizable", "search_artist_title", fallback: "아티스트")
+  /// 검색 기록이 없어요
+  public static let searchEmptyTitle = Strings.tr("Localizable", "search_empty_title", fallback: "검색 기록이 없어요")
+  /// 공연 정보
+  public static let searchPerformanceTitle = Strings.tr("Localizable", "search_performance_title", fallback: "공연 정보")
+  /// 모두삭제
+  public static let searchQueryButtonTitle = Strings.tr("Localizable", "search_query_button_title", fallback: "모두삭제")
+  /// 최근검색어
+  public static let searchQueryTitle = Strings.tr("Localizable", "search_query_title", fallback: "최근검색어")
   /// Apple로 시작하기
   public static let socialLoginAppleButton = Strings.tr("Localizable", "socialLogin_apple_button", fallback: "Apple로 시작하기")
   /// 잊지않고 내한공연 즐기러가요


### PR DESCRIPTION
<!--- 
Pull Request 제목은 반드시 아래의 형식을 따라야 합니다.
[<Category>] <issue number> <description> (e.g. "[Feature] #123 새로운 제스쳐 추가") 
-->

## Describe
<!--- 작업에 대한 간단한 설명 -->
- 검색화면 및 검색결과에 대한 화면 로직을 구현

## Works made
<!-- 작업한 내용을 기재합니다. 어떤 파일이 추가되었는지, 어떤 의도로 메서드를 만들었는지, 라이브러리 추가가 왜 필요했는지 등 최대한 자세하게 작성합니다. -->
- 최근 검색 특성상 잦은 데이터 변경이 존재하기때문에 `DiffableDataSource`를 적용해 애니메이션을 통해 구성하였습니다
- 텍스트 수에 따른 `returnKey` 적용 -> 텍스트가 존재한다면 `search` 존재하지않다면 `default`
- 텍스트가 비어있는 경우 `검색결과` -> `최근검색` 화면 이동
- 현재 화면에 따른 백버튼 로직 적용
1. 최근검색리스트인 경우 -> `홈화면`으로 pop
2. 검색결과화면인 경우 -> `최근검색리스트`로 이동
- 검색에 따른 `인디케이터` 적용
- 스와이프 및 탭에 따른 `resignResponder` 적용
- 검색결과 아티스트 셀 선택 시 레이아웃 변경 적용
- 검색결과 아티스트만 존재 시 레이아웃 적용
- 최근 검색 데이터가 존재여부에 따라 `emptyLabel` 적용
- 최근검색 좌측정렬을 위한 `LeftAlignedCollectionViewFlowLayout` 추가
- 최근 검색 데이터 `최대갯수 7개` 적용
- 최근 검색 최대 길이 `디바이스 너비-32` 적용

## Changes Made
<!--- 변경된 부분을 asis-tobe 형식으로 작성합니다. UI 변경이 있을 경우 반드시 모든 부분의 스크린샷을 첨부해야 하며 비즈니스 로직이 바뀌었다면 따로 적어줍니다. -->

### As-Is
<!-- 작업 이전 동작하던 부분을 기재합니다 -->
**기존 로직**
- 이전 작업한 검색화면이 없음

**스크린샷**
- 이전 작업한 검색화면이 없음

### To-BE
<!-- 작업 이후 변경된 부분을 기재합니다. -->
**변경 로직**

**스크린샷**
<img src="https://github.com/user-attachments/assets/268086ae-b3d0-44e4-8853-ad8f2bc0f68b" width="25%" alt="Image"><img src="https://github.com/user-attachments/assets/aca772eb-7dd5-4c40-a265-73aaa8bd3e1e" width="25%" alt="Image"><img src="https://github.com/user-attachments/assets/fdd13523-563a-44f5-ba5c-584668b73d35" width="25%" alt="Image"><img src="https://github.com/user-attachments/assets/64524e86-6a57-4b10-8f75-294d901047fa" width="25%" alt="Image">

https://github.com/user-attachments/assets/8dc86d55-92cb-453c-8e40-75f5d60896ea

## How to Test
<!--- 작업 내용을 확인하거나 테스트 할 수 있는 방법을 기재합니다.  -->
``` swift
let navigationController = UINavigationController()
window.rootViewController = navigationController
let coordinator = FeaturedSearchCoordinator(navigationController: navigationController)
coordinator.start()
```
- 위 코드를 통해 검색화면 확인 
- FeaturedSearchTextField를 통해 검색 혹은 버튼에 따른 로직 확인 
- 검색결과 아티스트 셀 클릭에 따른 레이아웃 변경 확인

## Issues Resolved
<!-- 
연관된 이슈나 다른 PR이 있다면 적어줍니다. '#123' 처럼 이슈 번호만 적지 말고, 이슈 타이틀이 같이 보일 수 있도록 bulletin list로 작성합니다.
e.g.
 - #123
 - #124
-->
- #67 

## Additional context
<!--- [선택사항] 추가적으로 공유해야 할 사항이 있다면 기재합니다. -->
- 아티스트 구독 성공 시 레이아웃 변경 및 스낵바 적용은 API연동 이후 구현
- NSDiffableDataSource특성상 Hashable해야하기에 일단 UUID를 이용해 구현, 추후 API Model에 id로 변경 예정
- `모두 삭제`버튼에 attribute적용 이후 텍스트가 사라져 일단 타이틀만 적용, 추후 수정 필요

## References
<!--- [선택사항] 참고한 자료가 있다면 기재합니다. -->
[최근검색리스트 레이아웃](https://apple-apeach.tistory.com/74)
[DiffableDataSource MVVM](https://medium.com/swlh/creating-a-reusable-uicollectionviewdiffabledatasource-object-using-mvvm-434976a1dfee)
[검색바 참고자료](https://ios-development.tistory.com/625)