### PR TITLE
#97 SPLabel 적용 후 baseline 안맞는 문제 해결

### DIFF
--- a/ShowPot/ShowPot/Common/Extension/NSAttributedString+Extension.swift
+++ b/ShowPot/ShowPot/Common/Extension/NSAttributedString+Extension.swift
@@ -11,15 +11,18 @@ struct AttributeStyle {
     let fontType: LanguageFont
     let lineBreakMode: NSLineBreakMode
     let alignment: NSTextAlignment
+    var multiline: Bool
     
     init(
         fontType: LanguageFont,
         lineBreakMode: NSLineBreakMode = .byTruncatingTail,
-        alignment: NSTextAlignment = .left
+        alignment: NSTextAlignment = .left,
+        multiline: Bool = false
     ) {
         self.fontType = fontType
         self.lineBreakMode = lineBreakMode
         self.alignment = alignment
+        self.multiline = multiline
     }
 }
 
@@ -88,7 +91,8 @@ extension NSAttributedString {
             string,
             fontType: style.fontType,
             lineBreakMode: style.lineBreakMode,
-            alignment: style.alignment
+            alignment: style.alignment,
+            multiline: style.multiline
         )
     }
     
@@ -96,20 +100,23 @@ extension NSAttributedString {
         _ string: String,
         fontType: LanguageFont,
         lineBreakMode: NSLineBreakMode = .byTruncatingTail,
-        alignment: NSTextAlignment = .left
+        alignment: NSTextAlignment = .left,
+        multiline: Bool = false
     ) {
-        
         let lineHeight = fontType.font.lineHeight * fontType.lineHeightMultiple
         
-        let attrStr = NSMutableAttributedString(string: string)
+        var attrStr = NSMutableAttributedString(string: string)
             .setFont(font: fontType.font)
             .setParagraphStyle(
-                lineHeightMultiple: fontType.lineHeightMultiple,
+                lineHeightMultiple: multiline ? fontType.lineHeightMultiple : 0,
                 lineBreakMode: lineBreakMode,
                 alignment: alignment
             )
             .setLetterSpacing(letterSpacingPercent: fontType.letterSpacing)
-            .setBaseLineOffset(baselineOffset: (lineHeight - fontType.font.lineHeight) / 2)
+
+        if multiline {
+            attrStr = attrStr.setBaseLineOffset(baselineOffset: (lineHeight - fontType.font.lineHeight) / 2)
+        }
         
         self.init(attributedString: attrStr)
     }

--- a/ShowPot/ShowPot/Common/UI/SPLabel.swift
+++ b/ShowPot/ShowPot/Common/UI/SPLabel.swift
@@ -7,9 +7,16 @@
 
 import UIKit
 
+/// Warning:
 class SPLabel: UILabel {
     
     var style: AttributeStyle
+    
+    override var numberOfLines: Int {
+        didSet {
+            self.style.multiline = isMultiline()
+        }
+    }
     
     init(style: AttributeStyle) {
         self.style = style
@@ -23,6 +30,7 @@ class SPLabel: UILabel {
     ) {
         let style = AttributeStyle(fontType: fontType, lineBreakMode: lineBreakMode, alignment: alignment)
         self.init(style: style)
+        self.numberOfLines = 1
     }
     
     required init?(coder: NSCoder) {
@@ -44,9 +52,17 @@ extension SPLabel {
         let newStyle = AttributeStyle(
             fontType: fontType ?? self.style.fontType,
             lineBreakMode: lineBreakMode ?? self.style.lineBreakMode,
-            alignment: alignment ?? self.style.alignment
+            alignment: alignment ?? self.style.alignment,
+            multiline: isMultiline()
         )
         
         self.style = newStyle
+    }
+}
+
+extension SPLabel {
+    
+    private func isMultiline() -> Bool {
+        return self.numberOfLines != 1
     }
 }

--- a/ShowPot/ShowPot/Presentation/Scene/Onboarding/CustomView/OnboardingCarouselCell.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Onboarding/CustomView/OnboardingCarouselCell.swift
@@ -17,7 +17,6 @@ final class OnboardingCarouselCell: UICollectionViewCell, ReusableCell {
     
     private lazy var titleLabel = SPLabel(KRFont.H0, alignment: .center).then { label in
         label.textColor = .gray800
-        label.numberOfLines = 0
     }
     
     private lazy var descriptionLabel = SPLabel(KRFont.H2, alignment: .center).then { label in


### PR DESCRIPTION
<!--- 
Pull Request 제목은 반드시 아래의 형식을 따라야 합니다.
[<Category>] <issue number> <description> (e.g. "[Feature] #123 새로운 제스쳐 추가") 
-->

## Describe
<!--- 작업에 대한 간단한 설명 -->
- SPLabel 작업 후 중앙정렬 관련 문제 해결

## Works made
<!-- 작업한 내용을 기재합니다. 어떤 파일이 추가되었는지, 어떤 의도로 메서드를 만들었는지, 라이브러리 추가가 왜 필요했는지 등 최대한 자세하게 작성합니다. -->
- multiline 텍스트에 한해서만 lineHeight 적용하도록 수정

## Changes Made
<!--- 변경된 부분을 asis-tobe 형식으로 작성합니다. UI 변경이 있을 경우 반드시 모든 부분의 스크린샷을 첨부해야 하며 비즈니스 로직이 바뀌었다면 따로 적어줍니다. -->

### As-Is
<!-- 작업 이전 동작하던 부분을 기재합니다 -->
**기존 로직**
```swift
 convenience init(
        _ string: String,
        fontType: LanguageFont,
        lineBreakMode: NSLineBreakMode = .byTruncatingTail,
        alignment: NSTextAlignment = .left
    ) {

        let lineHeight = fontType.font.lineHeight * fontType.lineHeightMultiple
        
        let attrStr = NSMutableAttributedString(string: string)
            .setFont(font: fontType.font)
            .setParagraphStyle(
                lineHeightMultiple: fontType.lineHeightMultiple,
                lineBreakMode: lineBreakMode,
                alignment: alignment
            )
            .setLetterSpacing(letterSpacingPercent: fontType.letterSpacing)
            .attrStr.setBaseLineOffset(baselineOffset: (lineHeight - fontType.font.lineHeight) / 2)
        
        self.init(attributedString: attrStr)
    }
```

**스크린샷**
<img src="https://github.com/user-attachments/assets/2d3ed13e-a2e6-40a1-8c4b-e8196111b860" width="25%" alt="Image"> <img src="https://github.com/user-attachments/assets/0e8aeba6-3c63-42a1-93bc-107b8fe71725" width="25%" alt="Image">

### To-BE
<!-- 작업 이후 변경된 부분을 기재합니다. -->
**변경 로직**

**스크린샷**
<img src="https://github.com/user-attachments/assets/f1efbae0-5fb0-48ac-92b6-b262311da2ee" width="25%" alt="Image"> <img src="https://github.com/user-attachments/assets/bee71441-bb34-4ae4-8a2b-7d7de93ef0af" width="25%" alt="Image">

## How to Test
<!--- 작업 내용을 확인하거나 테스트 할 수 있는 방법을 기재합니다.  -->
- `SPLabel`에 뒷배경 적용 후 vertical 중앙 정렬 여부 확인

## Issues Resolved
- closes #97 
<!-- 
연관된 이슈나 다른 PR이 있다면 적어줍니다. '#123' 처럼 이슈 번호만 적지 말고, 이슈 타이틀이 같이 보일 수 있도록 bulletin list로 작성합니다.
e.g.
 - #123
 - #124
-->

## Additional context
<!--- [선택사항] 추가적으로 공유해야 할 사항이 있다면 기재합니다. -->
- 해당 작업 이후에는 `numberOfLines`를 0 또는 2 이상으로 설정해야 `lineHeight` 관련 설정 적용됨
