### PR TITLE
[Refactor] #95 DateFormatterFactory 구현

### DIFF
--- a/ShowPot/ShowPot.xcodeproj/project.pbxproj
+++ b/ShowPot/ShowPot.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		707FF74F2C5CC2330026C82D /* PerformanceFilterHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 707FF74E2C5CC2330026C82D /* PerformanceFilterHeaderView.swift */; };
 		707FF7522C5DFCFD0026C82D /* AllPerformanceUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 707FF7512C5DFCFD0026C82D /* AllPerformanceUseCase.swift */; };
 		707FF7542C5DFD2E0026C82D /* DefaultAllPerformanceUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 707FF7532C5DFD2E0026C82D /* DefaultAllPerformanceUseCase.swift */; };
+		707FF7582C5FD9900026C82D /* DateFormatterFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 707FF7572C5FD9900026C82D /* DateFormatterFactory.swift */; };
 		70B81D5E2C580E8F00665EDD /* LeftAlignedCollectionViewFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70B81D5D2C580E8F00665EDD /* LeftAlignedCollectionViewFlowLayout.swift */; };
 		70B81D602C58D9CB00665EDD /* UIView+CALayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70B81D5F2C58D9CB00665EDD /* UIView+CALayer.swift */; };
 		70B81D672C5A2C9400665EDD /* PerformanceStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70B81D662C5A2C9400665EDD /* PerformanceStateView.swift */; };
@@ -180,6 +181,7 @@
 		707FF74E2C5CC2330026C82D /* PerformanceFilterHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceFilterHeaderView.swift; sourceTree = "<group>"; };
 		707FF7512C5DFCFD0026C82D /* AllPerformanceUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllPerformanceUseCase.swift; sourceTree = "<group>"; };
 		707FF7532C5DFD2E0026C82D /* DefaultAllPerformanceUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultAllPerformanceUseCase.swift; sourceTree = "<group>"; };
+		707FF7572C5FD9900026C82D /* DateFormatterFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormatterFactory.swift; sourceTree = "<group>"; };
 		70B81D5D2C580E8F00665EDD /* LeftAlignedCollectionViewFlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeftAlignedCollectionViewFlowLayout.swift; sourceTree = "<group>"; };
 		70B81D5F2C58D9CB00665EDD /* UIView+CALayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+CALayer.swift"; sourceTree = "<group>"; };
 		70B81D662C5A2C9400665EDD /* PerformanceStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceStateView.swift; sourceTree = "<group>"; };
@@ -519,6 +521,7 @@
 				7D3196412C133EC90015F88E /* Environment.swift */,
 				70107B092C198E5100F32042 /* LogHelper.swift */,
 				7DEACE4F2C1ED8EE00F37DA3 /* Font */,
+				707FF7572C5FD9900026C82D /* DateFormatterFactory.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -945,6 +948,7 @@
 				7D1E5FB62C0A23AB0012504D /* LoginCoordinator.swift in Sources */,
 				7D29813B2C01F27B00A619FB /* SampleRequest.swift in Sources */,
 				7DE569F62C557892006724EF /* UIView+UIGestureRecognizer.swift in Sources */,
+				707FF7582C5FD9900026C82D /* DateFormatterFactory.swift in Sources */,
 				7014673D2C3F0A3400750A54 /* FeaturedSearchButton.swift in Sources */,
 				7DEACE532C1ED96400F37DA3 /* ENFont.swift in Sources */,
 				701467802C53645900750A54 /* FeaturedWatchTheFullPerformanceFooterView.swift in Sources */,

--- a/ShowPot/ShowPot/Common/DateFormatterFactory.swift
+++ b/ShowPot/ShowPot/Common/DateFormatterFactory.swift
@@ -1,0 +1,49 @@
+//
+//  DateFormatterFactory.swift
+//  ShowPot
+//
+//  Created by 이건준 on 8/5/24.
+//
+
+import Foundation
+import Then
+
+enum DateFormatterFactory {
+    
+    private static func dateFormatter(locale: SPLocale) -> DateFormatter {
+        DateFormatter().then {
+            $0.locale = Locale(identifier: locale.identifier)
+        }
+    }
+    
+    /// Showpot프로젝트 공연에 관련된 날짜 포맷
+    static var dateWithPerformance: DateFormatter {
+        dateFormatter(locale: .eng).then { $0.dateFormat = "MM.dd(EEE) HH:mm" }
+    }
+    
+    /// `yyyy. MM. d`
+    static var dateWithDot: DateFormatter {
+        dateFormatter(locale: .eng).then { $0.dateFormat = "yyyy.MM.d" }
+    }
+    
+    /// Showpot프로젝트 티켓팅에 관련된 날짜 포맷
+    static var dateWithTicketing: DateFormatter {
+        dateFormatter(locale: .kor).then { $0.dateFormat = "MM월 dd일 (EEE) HH:mm" }
+    }
+}
+
+extension DateFormatterFactory {
+    private enum SPLocale {
+        case kor
+        case eng
+        
+        var identifier: String {
+            switch self {
+            case .kor:
+                return "ko_KR"
+            case .eng:
+                return "en_US"
+            }
+        }
+    }
+}

--- a/ShowPot/ShowPot/Presentation/Scene/Search/CustomView/PerformanceInfoCollectionViewCell.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Search/CustomView/PerformanceInfoCollectionViewCell.swift
@@ -41,6 +41,14 @@ final class PerformanceInfoCollectionViewCell: UICollectionViewCell, ReusableCel
         fatalError("init(coder:) has not been implemented")
     }
     
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        performanceImageView.image = nil
+        performanceTitleLabel.text = nil
+        performanceTimeLabel.text = nil
+        performanceLocationLabel.text = nil
+    }
+    
     private func setupLayouts() {
         [performanceImageView, performanceTitleLabel, performanceTimeLabel, performanceLocationLabel].forEach { contentView.addSubview($0) }
     }
@@ -90,12 +98,12 @@ struct PerformanceInfoCollectionViewCellModel: Hashable {
 
 extension PerformanceInfoCollectionViewCell {
     func configureUI(with model: PerformanceInfoCollectionViewCellModel) {
-        let performanceTime = DateFormatterFactory.dateWithDot.string(from: model.performanceTime ?? Date())
-
-        performanceImageView.kf.setImage(with: model.performanceImageURL)
-        performanceTitleLabel.setText(model.performanceTitle)
-        performanceTimeLabel.setText(performanceTime)
-        performanceLocationLabel.setText(model.performanceLocation)
+        self.configureUI(
+            performanceImageURL: model.performanceImageURL,
+            performanceTitle: model.performanceTitle,
+            performanceTime: model.performanceTime,
+            performanceLocation: model.performanceLocation
+        )
     }
     
     func configureUI(
@@ -104,11 +112,17 @@ extension PerformanceInfoCollectionViewCell {
         performanceTime: Date?,
         performanceLocation: String
     ) {
-        let performanceTime = DateFormatterFactory.dateWithDot.string(from: performanceTime ?? Date())
+        let formattedTime: String
+        if let time = performanceTime {
+            formattedTime = DateFormatterFactory.dateWithDot.string(from: time)
+        } else {
+            LogHelper.error("서버에서 내려준 포맷과 일치하지않습니다, 확인해주세요.")
+            formattedTime = ""
+        }
         
         performanceImageView.kf.setImage(with: performanceImageURL)
         performanceTitleLabel.setText(performanceTitle)
-        performanceTimeLabel.setText(performanceTime)
+        performanceTimeLabel.setText(formattedTime)
         performanceLocationLabel.setText(performanceLocation)
     }
 }

--- a/ShowPot/ShowPot/Presentation/Scene/Search/CustomView/PerformanceInfoCollectionViewCell.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Search/CustomView/PerformanceInfoCollectionViewCell.swift
@@ -90,14 +90,11 @@ struct PerformanceInfoCollectionViewCellModel: Hashable {
 
 extension PerformanceInfoCollectionViewCell {
     func configureUI(with model: PerformanceInfoCollectionViewCellModel) {
-        
-        let dateFormatter = DateFormatter() // TODO: #95 Date관련 공통함수로 코드 개선
-        dateFormatter.dateFormat = "yyyy.MM.d"
-        dateFormatter.locale = Locale(identifier: "en_US")
-        
+        let performanceTime = DateFormatterFactory.dateWithDot.string(from: model.performanceTime ?? Date())
+
         performanceImageView.kf.setImage(with: model.performanceImageURL)
         performanceTitleLabel.setText(model.performanceTitle)
-        performanceTimeLabel.setText(dateFormatter.string(from: model.performanceTime ?? Date()))
+        performanceTimeLabel.setText(performanceTime)
         performanceLocationLabel.setText(model.performanceLocation)
     }
     
@@ -107,14 +104,11 @@ extension PerformanceInfoCollectionViewCell {
         performanceTime: Date?,
         performanceLocation: String
     ) {
-        
-        let dateFormatter = DateFormatter() // TODO: #95 Date관련 공통함수로 코드 개선
-        dateFormatter.dateFormat = "yyyy.MM.d"
-        dateFormatter.locale = Locale(identifier: "en_US")
+        let performanceTime = DateFormatterFactory.dateWithDot.string(from: performanceTime ?? Date())
         
         performanceImageView.kf.setImage(with: performanceImageURL)
         performanceTitleLabel.setText(performanceTitle)
-        performanceTimeLabel.setText(dateFormatter.string(from: performanceTime ?? Date()))
+        performanceTimeLabel.setText(performanceTime)
         performanceLocationLabel.setText(performanceLocation)
     }
 }

--- a/ShowPot/ShowPot/Presentation/Scene/Tab/Featured/CustomView/FeaturedWatchTheFullPerformanceFooterView.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Tab/Featured/CustomView/FeaturedWatchTheFullPerformanceFooterView.swift
@@ -13,8 +13,6 @@ import Then
 
 final class FeaturedWatchTheFullPerformanceFooterView: UICollectionReusableView, ReusableCell {
     
-    static let identifier = String(describing: FeaturedWatchTheFullPerformanceFooterView.self) // TODO: #46 identifier 지정코드로 변환
-    
     var didTappedButton: ControlEvent<Void> {
         watchTheFullPerformanceButton.rx.tap
     }

--- a/ShowPot/ShowPot/Presentation/Scene/Tab/Featured/CustomView/FeaturedWithButtonHeaderView.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Tab/Featured/CustomView/FeaturedWithButtonHeaderView.swift
@@ -15,7 +15,6 @@ import Then
 final class FeaturedWithButtonHeaderView: UICollectionReusableView, ReusableCell {
     
     private let disposeBag = DisposeBag()
-    static let identifier = String(describing: FeaturedWithButtonHeaderView.self) 
     
     var buttonTapped: ControlEvent<UITapGestureRecognizer> {
         tapGesture.rx.event

--- a/ShowPot/ShowPot/Presentation/Scene/Tab/Featured/CustomView/PerformanceStateView.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Tab/Featured/CustomView/PerformanceStateView.swift
@@ -89,8 +89,8 @@ extension PerformanceStateView {
         chipTitle: String?
     ) {
         if let performanceDate = performanceDate {
-            let performanceDate = DateFormatterFactory.dateWithPerformance.string(from: performanceDate)
-            ticketingOpenTimeLabel.setText(performanceDate)
+            let formattedDate = DateFormatterFactory.dateWithPerformance.string(from: performanceDate)
+            ticketingOpenTimeLabel.setText(formattedDate)
         } else {
             ticketingOpenTimeLabel.text = nil
         }

--- a/ShowPot/ShowPot/Presentation/Scene/Tab/Featured/CustomView/PerformanceStateView.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Tab/Featured/CustomView/PerformanceStateView.swift
@@ -90,7 +90,7 @@ extension PerformanceStateView {
     ) {
         if let performanceDate = performanceDate {
             let formattedDate = DateFormatterFactory.dateWithPerformance.string(from: performanceDate)
-            ticketingOpenTimeLabel.setText(formattedDate)
+            ticketingOpenTimeLabel.setText(formattedDate.uppercased())
         } else {
             ticketingOpenTimeLabel.text = nil
         }

--- a/ShowPot/ShowPot/Presentation/Scene/Tab/Featured/CustomView/PerformanceStateView.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Tab/Featured/CustomView/PerformanceStateView.swift
@@ -89,10 +89,8 @@ extension PerformanceStateView {
         chipTitle: String?
     ) {
         if let performanceDate = performanceDate {
-            let dateFormatter = DateFormatter() // TODO: #95 Date관련 공통함수로 코드 개선
-            dateFormatter.dateFormat = "MM.dd(EEE) HH:mm"
-            dateFormatter.locale = Locale(identifier: "en_US")
-            ticketingOpenTimeLabel.setText(dateFormatter.string(from: performanceDate))
+            let performanceDate = DateFormatterFactory.dateWithPerformance.string(from: performanceDate)
+            ticketingOpenTimeLabel.setText(performanceDate)
         } else {
             ticketingOpenTimeLabel.text = nil
         }

--- a/ShowPot/ShowPot/Presentation/Scene/Tab/Featured/FeaturedViewController.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Tab/Featured/FeaturedViewController.swift
@@ -104,7 +104,7 @@ extension FeaturedViewController: UICollectionViewDelegate, UICollectionViewData
         let type = viewModel.featuredSectionModel[indexPath.section]
         switch type {
         case .subscribeGenre, .subscribeArtist:
-            let headerView = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: FeaturedWithButtonHeaderView.identifier, for: indexPath) as? FeaturedWithButtonHeaderView ?? FeaturedWithButtonHeaderView()
+            let headerView = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: FeaturedWithButtonHeaderView.reuseIdentifier, for: indexPath) as? FeaturedWithButtonHeaderView ?? FeaturedWithButtonHeaderView()
             headerView.configureUI(with: .init(headerTitle: type.headerTitle))
             headerView.buttonTapped
                 .subscribe(with: self) { owner, _ in
@@ -118,7 +118,7 @@ extension FeaturedViewController: UICollectionViewDelegate, UICollectionViewData
                 headerView.configureUI(with: type.headerTitle)
                 return headerView
             }
-            let footerView = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: FeaturedWatchTheFullPerformanceFooterView.identifier, for: indexPath) as? FeaturedWatchTheFullPerformanceFooterView ?? FeaturedWatchTheFullPerformanceFooterView()
+            let footerView = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: FeaturedWatchTheFullPerformanceFooterView.reuseIdentifier, for: indexPath) as? FeaturedWatchTheFullPerformanceFooterView ?? FeaturedWatchTheFullPerformanceFooterView()
             footerView.didTappedButton
                 .subscribe(with: self) { owner, _ in
                     owner.didTappedWatchTheFullPerformanceButtonSubject.onNext(())


### PR DESCRIPTION
<!--- 
Pull Request 제목은 반드시 아래의 형식을 따라야 합니다.
[<Category>] <issue number> <description> (e.g. "[Feature] #123 새로운 제스쳐 추가") 
-->

## Describe
<!--- 작업에 대한 간단한 설명 -->
- 서버를 통해 받아온 날짜관련 문자열처리를 효율적으로 작업하기위한 `DateFormatterFactory`구현

## Works made
<!-- 작업한 내용을 기재합니다. 어떤 파일이 추가되었는지, 어떤 의도로 메서드를 만들었는지, 라이브러리 추가가 왜 필요했는지 등 최대한 자세하게 작성합니다. -->
- `Date`타입 관련 포맷팅을 `DateFormatterFactory`내부에서 작업하여 손쉽게 원하는 포맷의 날짜 문자열로 변환할 수 있도록 구현
- 프로젝트상 사용하는 날짜타입에 대한 `Locale`에 하나에만 국한되지않아 `SPLocale`열거형을 이용해 `DateFormatter`생성

## Changes Made
<!--- 변경된 부분을 asis-tobe 형식으로 작성합니다. UI 변경이 있을 경우 반드시 모든 부분의 스크린샷을 첨부해야 하며 비즈니스 로직이 바뀌었다면 따로 적어줍니다. -->

### As-Is
<!-- 작업 이전 동작하던 부분을 기재합니다 -->
**기존 로직**
``` swift
let dateFormatter = DateFormatter() 
dateFormatter.dateFormat = "yyyy.MM.d"
dateFormatter.locale = Locale(identifier: "en_US")
dateFormatter.string(from: model.performanceTime ?? Date())
```
- 기존에는 원하는 포맷팅에 맞춰 일일이 구현해준 이후 `.string(from:)`을 이용해 변환 후 작업

**스크린샷**

### To-BE
<!-- 작업 이후 변경된 부분을 기재합니다. -->
**변경 로직**
``` swift
let performanceTime = DateFormatterFactory.dateWithDot.string(from: performanceTime ?? Date())
```
- 미리 작성된 `DateFormatterFactory`의 포맷형식을 꺼내어 원하는 형태의 날짜 문자열로 변환하여 사용

**스크린샷**
<img src="https://github.com/user-attachments/assets/e7dd0921-fb44-4624-8afa-d1dad3489474" width="25%" alt="Image">
<img src="https://github.com/user-attachments/assets/1aaf4ac8-38ac-4f11-9a6c-1677090d8029" width="25%" alt="Image">

## How to Test
<!--- 작업 내용을 확인하거나 테스트 할 수 있는 방법을 기재합니다.  -->
``` swift
let currentDate = Date()
let dateToString = DateFormatterFactory.dateWithDot.string(from: currentDate) // 2024.08.5
DateFormatterFactory.dateWithDot.date(from: dateToString) 
```
- `DateFormatterFactory`내부에 원하는 포맷형식을 지정해준 이후 위 코드와 같이 `.string(from:)`혹은 `date(from:)`을 통해서 변환하여 사용

## Issues Resolved
<!-- 
연관된 이슈나 다른 PR이 있다면 적어줍니다. '#123' 처럼 이슈 번호만 적지 말고, 이슈 타이틀이 같이 보일 수 있도록 bulletin list로 작성합니다.
e.g.
 - #123
 - #124
-->
- #95 

## Additional context
<!--- [선택사항] 추가적으로 공유해야 할 사항이 있다면 기재합니다. -->
- 부가적으로 `ReusableCell`채택하면 굳이 따로 identifier를 만들지않아도 되는거같아서 기존 식별자코드 대신 `reuseidentifier`로 대체하였습니다
- 현재 `DateFormatter`형식중 `"MM.dd(EEE) HH:mm"`(쇼팟 공연날짜에 관련된 포맷팅)을 사용할때에 `06.10(MON) 19:00`가 아닌 `06.10(Mon) 19:00`으로 나오고있는데 요일관련하여 전부 대문자로 변환하는 형식이 없는거같아 따로 `replacingOccurrences` 혹은 `uppercased`를 이용해 변환하여 작업해야할꺼같습니다
