### PR TITLE
[Feature] #123 드롭다운 UI 및 로직 작성

### DIFF
--- a/ShowPot/ShowPot.xcodeproj/project.pbxproj
+++ b/ShowPot/ShowPot.xcodeproj/project.pbxproj
@@ -117,6 +117,7 @@
 		70F3C1492C6FBB0300786738 /* ClosedShowListEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F3C1482C6FBB0300786738 /* ClosedShowListEmptyView.swift */; };
 		70F3C14B2C6FBBA200786738 /* InterestShowListEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F3C14A2C6FBBA200786738 /* InterestShowListEmptyView.swift */; };
 		70F3C1502C70FD5700786738 /* ShowDeleteButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F3C14F2C70FD5700786738 /* ShowDeleteButtonView.swift */; };
+		70F3C14E2C706A6A00786738 /* iOSDropDown in Frameworks */ = {isa = PBXBuildFile; productRef = 70F3C14D2C706A6A00786738 /* iOSDropDown */; };
 		7D13C3522C35A8A30017AE93 /* MainTabController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D13C3512C35A8A30017AE93 /* MainTabController.swift */; };
 		7D1B56B32C66371500EA70C4 /* GradientImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D1B56B22C66371500EA70C4 /* GradientImageView.swift */; };
 		7D1E5FAD2C0A20950012504D /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D1E5FAC2C0A20950012504D /* LoginViewController.swift */; };
@@ -395,6 +396,7 @@
 				70F3C1172C6BA19700786738 /* ScalingCarousel in Frameworks */,
 				70107B682C216A4200F32042 /* KakaoSDKFriend in Frameworks */,
 				70107B6E2C216A4200F32042 /* KakaoSDKShare in Frameworks */,
+				70F3C14E2C706A6A00786738 /* iOSDropDown in Frameworks */,
 				70107B6A2C216A4200F32042 /* KakaoSDKFriendCore in Frameworks */,
 				701467402C401C0C00750A54 /* Kingfisher in Frameworks */,
 				70107B5E2C216A4200F32042 /* KakaoSDK in Frameworks */,
@@ -1138,6 +1140,7 @@
 				7D43E2052C5E790100D94898 /* RxDataSources */,
 				7D43E2082C5E7A5700D94898 /* RxGesture */,
 				70F3C1162C6BA19700786738 /* ScalingCarousel */,
+				70F3C14D2C706A6A00786738 /* iOSDropDown */,
 			);
 			productName = ShowPot;
 			productReference = 7D2980FC2C01E1D000A619FB /* ShowPot.app */;
@@ -1179,6 +1182,7 @@
 				7D43E2022C5E790100D94898 /* XCRemoteSwiftPackageReference "RxDataSources" */,
 				7D43E2072C5E7A5700D94898 /* XCRemoteSwiftPackageReference "RxGesture" */,
 				70F3C1152C6BA19700786738 /* XCRemoteSwiftPackageReference "ScalingCarousel" */,
+				70F3C14C2C706A6A00786738 /* XCRemoteSwiftPackageReference "iOSDropDown" */,
 			);
 			productRefGroup = 7D2980FD2C01E1D000A619FB /* Products */;
 			projectDirPath = "";
@@ -1655,6 +1659,14 @@
 				minimumVersion = 3.2.0;
 			};
 		};
+		70F3C14C2C706A6A00786738 /* XCRemoteSwiftPackageReference "iOSDropDown" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/jriosdev/iOSDropDown";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.4.0;
+			};
+		};
 		7D2DCAB72C269BF700389FBF /* XCRemoteSwiftPackageReference "Alamofire" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Alamofire/Alamofire.git";
@@ -1790,6 +1802,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 70F3C1152C6BA19700786738 /* XCRemoteSwiftPackageReference "ScalingCarousel" */;
 			productName = ScalingCarousel;
+		};
+		70F3C14D2C706A6A00786738 /* iOSDropDown */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 70F3C14C2C706A6A00786738 /* XCRemoteSwiftPackageReference "iOSDropDown" */;
+			productName = iOSDropDown;
 		};
 		7D2DCAB82C269BF700389FBF /* Alamofire */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/ShowPot/ShowPot/Domain/UseCase/AllPerformance/AllPerformanceUseCase.swift
+++ b/ShowPot/ShowPot/Domain/UseCase/AllPerformance/AllPerformanceUseCase.swift
@@ -21,5 +21,5 @@ struct FeaturedPerformanceWithTicketOnSaleSoonCellModel: Hashable { // TODO: - U
 
 protocol AllPerformanceUseCase {
     var performanceList: BehaviorRelay<[FeaturedPerformanceWithTicketOnSaleSoonCellModel]> { get }
-    func fetchAllPerformance(isOnlyUpcoming: Bool)
+    func fetchAllPerformance(state: ShowFilterState)
 }

--- a/ShowPot/ShowPot/Domain/UseCase/AllPerformance/DefaultAllPerformanceUseCase.swift
+++ b/ShowPot/ShowPot/Domain/UseCase/AllPerformance/DefaultAllPerformanceUseCase.swift
@@ -13,8 +13,11 @@ final class DefaultAllPerformanceUseCase: AllPerformanceUseCase {
     
     var performanceList: BehaviorRelay<[FeaturedPerformanceWithTicketOnSaleSoonCellModel]> = BehaviorRelay(value: [])
     
-    func fetchAllPerformance(isOnlyUpcoming: Bool) {
-        if !isOnlyUpcoming {
+    func fetchAllPerformance(state: ShowFilterState) {
+        
+        LogHelper.debug("전체공연 검색\n오픈예정유무: \(state.isOnlyUpcoming)\n어떤필터타입: \(state.type)")
+        
+        if !state.isOnlyUpcoming {
             performanceList.accept(
                 [ // FIXME: - 추후 전체공연조회 API연동예정
                     .init(

--- a/ShowPot/ShowPot/Presentation/Scene/AllPerformance/AllPerformanceViewModel.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/AllPerformance/AllPerformanceViewModel.swift
@@ -122,9 +122,9 @@ enum ShowFilterType: CaseIterable {
     var text: String {
         switch self {
         case .popular:
-            return "인기순"
+            return Strings.allShowDropdownPopularTitle
         case .upcoming:
-            return "임박순"
+            return Strings.allShowDropdownUpcomingTitle
         }
     }
     

--- a/ShowPot/ShowPot/Presentation/Scene/AllPerformance/AllPerformanceViewModel.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/AllPerformance/AllPerformanceViewModel.swift
@@ -17,6 +17,8 @@ final class AllPerformanceViewModel: ViewModelType {
     
     private let usecase: AllPerformanceUseCase
     private let performanceListRelay = BehaviorRelay<[FeaturedPerformanceWithTicketOnSaleSoonCellModel]>(value: [])
+    private let showPrioritySubject = BehaviorSubject<ShowFilterType>(value: .popular)
+    private let isUpcomingSubject = BehaviorSubject<Bool>(value: false)
 
     var dataSource: DataSource?
     
@@ -26,25 +28,24 @@ final class AllPerformanceViewModel: ViewModelType {
     }
     
     struct Input {
-        let initializePerformance: Observable<Void>
         let didTappedCheckBoxButton: Observable<Bool>
         let didTappedPerformance: Observable<IndexPath>
         let didTappedBackButton: Observable<Void>
         let didTappedSearchButton: Observable<Void>
+        let didTappedDropDown: Observable<String>
     }
     
-    struct Output {}
+    struct Output {
+        let dropdownOptions: Observable<[String]>
+        let defaultSelectedOption: Observable<String>
+    }
     
-    @discardableResult
     func transform(input: Input) -> Output {
         
         usecase.performanceList
-            .bind(to: performanceListRelay)
-            .disposed(by: disposeBag)
-        
-        input.initializePerformance
-            .subscribe(with: self) { owner, _ in
-                owner.fetchAllPerformanceList()
+            .subscribe(with: self) { owner, model in
+                owner.performanceListRelay.accept(model)
+                owner.updateDataSource()
             }
             .disposed(by: disposeBag)
         
@@ -62,34 +63,35 @@ final class AllPerformanceViewModel: ViewModelType {
         
         input.didTappedCheckBoxButton
             .map { !$0 }
-            .subscribe(with: self) { owner, isChecked in
-                isChecked ? owner.fetchOnlyUpcomingPerformance() : owner.fetchAllPerformanceList()
-            }
+            .bind(to: isUpcomingSubject)
             .disposed(by: disposeBag)
+        
+        input.didTappedDropDown
+            .compactMap { ShowFilterType.from(text: $0) }
+            .bind(to: showPrioritySubject)
+            .disposed(by: disposeBag)
+        
+        Observable.combineLatest(
+            isUpcomingSubject,
+            showPrioritySubject
+        )
+        .subscribe(with: self) { owner, result in
+            let (isOnlyUpcoming, type) = result
+            owner.usecase.fetchAllPerformance(state: .init(type: type, isOnlyUpcoming: isOnlyUpcoming))
+        }
+        .disposed(by: disposeBag)
         
         input.didTappedPerformance
             .subscribe(with: self) { owner, indexPath in
-                print("선택한 공연정보: \(owner.performanceListRelay.value[indexPath.row])")
+                LogHelper.debug("선택한 공연정보: \(owner.performanceListRelay.value[indexPath.row])")
             }
             .disposed(by: disposeBag)
         
-        return Output()
+        let dropdownOptions = Observable.just([ShowFilterType.upcoming.text])
+        let defaultSelectedOption = Observable.just(ShowFilterType.popular.text)
+        
+        return Output(dropdownOptions: dropdownOptions, defaultSelectedOption: defaultSelectedOption)
     }
-}
-
-extension AllPerformanceViewModel {
-    
-    private func fetchAllPerformanceList() {
-        usecase.fetchAllPerformance(isOnlyUpcoming: false)
-        updateDataSource()
-    }
-    
-    private func fetchOnlyUpcomingPerformance() {
-        usecase.fetchAllPerformance(isOnlyUpcoming: true)
-        updateDataSource()
-
-    }
-    
 }
 
 // MARK: - For NSDiffableDataSource
@@ -111,4 +113,27 @@ extension AllPerformanceViewModel {
         snapshot.appendItems(performanceList)
         dataSource?.apply(snapshot)
     }
+}
+
+enum ShowFilterType: CaseIterable {
+    case popular
+    case upcoming
+    
+    var text: String {
+        switch self {
+        case .popular:
+            return "인기순"
+        case .upcoming:
+            return "임박순"
+        }
+    }
+    
+    static func from(text: String) -> Self? {
+        ShowFilterType.allCases.first(where: { $0.text == text })
+    }
+}
+
+struct ShowFilterState {
+    let type: ShowFilterType
+    let isOnlyUpcoming: Bool
 }

--- a/ShowPot/ShowPot/Presentation/Scene/AllPerformance/CustomView/PerformanceFilterHeaderView.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/AllPerformance/CustomView/PerformanceFilterHeaderView.swift
@@ -31,9 +31,9 @@ final class PerformanceFilterHeaderView: UICollectionReusableView, ReusableCell 
     private let disposeBag = DisposeBag()
     private let checkBoxButton = CheckBoxButton(title: Strings.allPerformanceCheckboxTitle)
     private lazy var dropdown = DropDown(frame: .init(x: .zero, y: .zero, width: .zero, height: 25)).then {
-        $0.backgroundColor = .gray500
-        $0.rowBackgroundColor = .gray500
-        $0.textColor = .gray400
+        $0.backgroundColor = .gray700
+        $0.rowBackgroundColor = .gray700
+        $0.textColor = .gray000
         $0.font = KRFont.B1_semibold.font
         $0.itemsColor = .gray000
         $0.arrowColor = .gray200
@@ -41,7 +41,7 @@ final class PerformanceFilterHeaderView: UICollectionReusableView, ReusableCell 
         $0.isSearchEnable = false
         $0.checkMarkEnabled = false
         $0.arrowSize = 12
-        $0.selectedRowColor = .gray500
+        $0.selectedRowColor = .gray700
         $0.rowHeight = 40
         $0.cornerRadius = 2
     }

--- a/ShowPot/ShowPot/Presentation/Scene/AllPerformance/CustomView/PerformanceFilterHeaderView.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/AllPerformance/CustomView/PerformanceFilterHeaderView.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+import iOSDropDown
 import RxSwift
 import SnapKit
 import Then
@@ -23,8 +24,20 @@ final class PerformanceFilterHeaderView: UICollectionReusableView, ReusableCell 
     
     private let disposeBag = DisposeBag()
     private let checkBoxButton = CheckBoxButton(title: Strings.allPerformanceCheckboxTitle)
-    private let filterAreaView = UIView().then { // FIXME: - 추후 필터를 위한 UI로 변경 필수
-        $0.backgroundColor = .red
+    private lazy var dropdown = DropDown(frame: .init(x: .zero, y: .zero, width: .zero, height: 25)).then {
+        $0.backgroundColor = .gray500
+        $0.rowBackgroundColor = .gray500
+        $0.textColor = .gray400
+        $0.font = KRFont.B1_semibold.font
+        $0.itemsColor = .gray000
+        $0.arrowColor = .gray200
+        $0.textAlignment = .center
+        $0.isSearchEnable = false
+        $0.checkMarkEnabled = false
+        $0.arrowSize = 12
+        $0.selectedRowColor = .gray500
+        $0.rowHeight = 40
+        $0.cornerRadius = 2
     }
     
     override init(frame: CGRect) {
@@ -39,7 +52,7 @@ final class PerformanceFilterHeaderView: UICollectionReusableView, ReusableCell 
     }
     
     private func setupLayouts() {
-        [checkBoxButton, filterAreaView].forEach { addSubview($0) }
+        [checkBoxButton, dropdown].forEach { addSubview($0) }
     }
     
     private func setupConstraints() {
@@ -48,7 +61,7 @@ final class PerformanceFilterHeaderView: UICollectionReusableView, ReusableCell 
             $0.directionalVerticalEdges.equalToSuperview().inset(8)
         }
         
-        filterAreaView.snp.makeConstraints {
+        dropdown.snp.makeConstraints {
             $0.trailing.equalToSuperview().inset(16)
             $0.width.equalTo(83)
             $0.height.equalTo(40)
@@ -60,5 +73,22 @@ final class PerformanceFilterHeaderView: UICollectionReusableView, ReusableCell 
         didTappedCheckBox
             .subscribe(checkBoxButton.rx.isChecked)
             .disposed(by: disposeBag)
+    }
+}
+
+extension PerformanceFilterHeaderView {
+    func configureUI(
+        dropdownOptions: [String],
+        defaultSelectedOption: String
+    ) {
+        configureDropdown(options: dropdownOptions, defaultOption: defaultSelectedOption)
+    }
+    
+    private func configureDropdown(options: [String], defaultOption: String) {
+        dropdown.optionArray = options
+        if let defaultIndex = options.firstIndex(of: defaultOption) {
+            dropdown.selectedIndex = defaultIndex
+        }
+        dropdown.text = defaultOption
     }
 }

--- a/ShowPot/ShowPot/Presentation/Scene/AllPerformance/CustomView/PerformanceFilterHeaderView.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/AllPerformance/CustomView/PerformanceFilterHeaderView.swift
@@ -12,7 +12,13 @@ import RxSwift
 import SnapKit
 import Then
 
+protocol PerformanceFilterHeaderViewDelegate: AnyObject {
+    func selectedDropdown(text: String)
+}
+
 final class PerformanceFilterHeaderView: UICollectionReusableView, ReusableCell {
+    
+    weak var delegate: PerformanceFilterHeaderViewDelegate?
     
     var didTappedCheckBox: Observable<Bool> {
         checkBoxButton.rx.tap
@@ -70,6 +76,16 @@ final class PerformanceFilterHeaderView: UICollectionReusableView, ReusableCell 
     }
     
     private func bind() {
+        
+        dropdown.didSelect { [weak self] (selectedText, index, id) in
+            guard let self = self,
+                  let text = self.dropdown.text else { return }
+            
+            self.dropdown.optionArray.removeAll(where: { $0 == selectedText })
+            self.dropdown.optionArray.append(text)
+            self.delegate?.selectedDropdown(text: selectedText)
+        }
+        
         didTappedCheckBox
             .subscribe(checkBoxButton.rx.isChecked)
             .disposed(by: disposeBag)

--- a/ShowPot/ShowPot/Resource/Localizable/Localizable.strings
+++ b/ShowPot/ShowPot/Resource/Localizable/Localizable.strings
@@ -61,6 +61,8 @@
 // 전체 공연 화면
 "all_performance_title" = "전체공연";
 "all_performance_checkbox_title" = "오픈예정 티켓만 보기";
+"all_show_dropdown_popular_title" = "인기순";
+"all_show_dropdown_upcoming_title" = "임박순";
 
 // 아티스트구독 화면
 "subscribe_artist_navigation_title" = "아티스트 구독하기";

--- a/ShowPot/ShowPot/Resource/Localizable/Strings+Generated.swift
+++ b/ShowPot/ShowPot/Resource/Localizable/Strings+Generated.swift
@@ -14,6 +14,10 @@ public enum Strings {
   public static let allPerformanceCheckboxTitle = Strings.tr("Localizable", "all_performance_checkbox_title", fallback: "오픈예정 티켓만 보기")
   /// 전체공연
   public static let allPerformanceTitle = Strings.tr("Localizable", "all_performance_title", fallback: "전체공연")
+  /// 인기순
+  public static let allShowDropdownPopularTitle = Strings.tr("Localizable", "all_show_dropdown_popular_title", fallback: "인기순")
+  /// 임박순
+  public static let allShowDropdownUpcomingTitle = Strings.tr("Localizable", "all_show_dropdown_upcoming_title", fallback: "임박순")
   /// Localizable.strings
   ///   ShowPot
   /// 


### PR DESCRIPTION
<!--- 
Pull Request 제목은 반드시 아래의 형식을 따라야 합니다.
[<Category>] <issue number> <description> (e.g. "[Feature] #123 새로운 제스쳐 추가") 
-->

## Describe
<!--- 작업에 대한 간단한 설명 -->
- 기존 전체공연화면의 드롭다운 UI와 그에 따른 로직을 구현

## Works made
<!-- 작업한 내용을 기재합니다. 어떤 파일이 추가되었는지, 어떤 의도로 메서드를 만들었는지, 라이브러리 추가가 왜 필요했는지 등 최대한 자세하게 작성합니다. -->
- `iOSDropDown`라이브러리 추가
- `오픈예정 유무`, `인기순, 임박순`필터 로직 구현

## Changes Made
<!--- 변경된 부분을 asis-tobe 형식으로 작성합니다. UI 변경이 있을 경우 반드시 모든 부분의 스크린샷을 첨부해야 하며 비즈니스 로직이 바뀌었다면 따로 적어줍니다. -->

### As-Is
<!-- 작업 이전 동작하던 부분을 기재합니다 -->
**기존 로직**
``` swift
private let filterAreaView = UIView().then { 
    $0.backgroundColor = .red
}

/// DefaultAllPerformanceUseCase
func fetchAllPerformance(isOnlyUpcoming: Bool)
```
- 기존 드롭다운 UI에 대한 레이아웃을 단순 영역을 잡는 뷰로 대체
- 필터로직이 `오픈예정`만 존재

**스크린샷**
<img src="https://github.com/user-attachments/assets/14cbdebc-99bf-4719-a165-90e4978dc49d" width="25%" alt="Image">

### To-BE
<!-- 작업 이후 변경된 부분을 기재합니다. -->
**변경 로직**
``` swift
private lazy var dropdown = DropDown()

/// DefaultAllPerformanceUseCase
func fetchAllPerformance(state: ShowFilterState)

/// AllPerformanceViewModel
struct ShowFilterState {
    let type: ShowFilterType
    let isOnlyUpcoming: Bool
}

Observable.combineLatest(
    isUpcomingSubject,
    showPrioritySubject
)
.subscribe(with: self) { owner, result in
    let (isOnlyUpcoming, type) = result
    owner.usecase.fetchAllPerformance(state: .init(type: type, isOnlyUpcoming: isOnlyUpcoming))
}
.disposed(by: disposeBag)
```
- `오픈예정 유무` 및 `인기순, 임박순`에 대한 필터로직 구축 
- `iOSDropdown`라이브러리를 이용해 드롭다운 UI로 대체

**스크린샷**
<img src="https://github.com/user-attachments/assets/f140c557-3f2c-4942-90a7-a61460192a65" width="25%" alt="Image">

## How to Test
<!--- 작업 내용을 확인하거나 테스트 할 수 있는 방법을 기재합니다.  -->
- `전체공연보러가기`버튼을 통해 전체공연화면으로 이동 
- `DropDown`의 `인기순`, `임박순` 혹은 `오픈예정`체크박스 클릭을 통해 어떤식으로 필터로그가 찍히는지 확인

## Issues Resolved
<!-- 
연관된 이슈나 다른 PR이 있다면 적어줍니다. '#123' 처럼 이슈 번호만 적지 말고, 이슈 타이틀이 같이 보일 수 있도록 bulletin list로 작성합니다.
e.g.
 - #123
 - #124
-->
- #123 

## Additional context
<!--- [선택사항] 추가적으로 공유해야 할 사항이 있다면 기재합니다. -->
- 기존 `인기순`, `임박순`밖에 존재하지않지만 `추천순`과 같이 추가될 여지가 있다 판단해 이 또한 `AllPerformanceViewModel`에서 간편히 추가할 수 있도록 구현했어요.
``` swift
enum ShowFilterType: CaseIterable {
    case popular
    case upcoming
    case recommended <- `추천순` 추가
}

let dropdownOptions = Observable.just([ShowFilterType.upcoming.text, ShowFilterType.recommended.text]) <- `추천순`옵션 추가
let defaultSelectedOption = Observable.just(ShowFilterType.popular.text)

return Output(dropdownOptions: dropdownOptions, defaultSelectedOption: defaultSelectedOption)
```
- 위 예시 코드처럼 `ShowFilterType`에 `recommended`케이스문을 추가하여 `dropdownOptions`를 이용해 간단히 추가하면 이 또한 올바르게 드롭다운 기능이 동작합니다

## References
<!--- [선택사항] 참고한 자료가 있다면 기재합니다. -->
[iOSDropDown 라이브러리 링크](https://github.com/jriosdev/iOSDropDown)