### PR TITLE
[Fix] #144 알림성공 시 스낵바 표출

### DIFF
--- a/ShowPot/ShowPot/Common/UI/BottomSheet/TicketingAlarm/TicketingAlarmBottomSheetViewController.swift
+++ b/ShowPot/ShowPot/Common/UI/BottomSheet/TicketingAlarm/TicketingAlarmBottomSheetViewController.swift
@@ -15,6 +15,8 @@ final class TicketingAlarmBottomSheetViewController: BottomSheetViewController {
     private let disposeBag = DisposeBag()
     private let viewModel: TicketingAlarmViewModel
     
+    var successAlarmUpdateSubject = PublishSubject<Void>()
+    
     private let titleLabel = SPLabel(KRFont.H1).then {
         $0.textColor = .gray100
         $0.setText(Strings.myShowTicketBottomsheetTitle)
@@ -90,6 +92,16 @@ final class TicketingAlarmBottomSheetViewController: BottomSheetViewController {
         output.isEnabledBottomButton
             .drive(alarmSettingButton.rx.isEnabled)
             .disposed(by: disposeBag)
+        
+        output.alarmUpdateResult
+            .emit(with: self) { owner, success in
+                owner.dismissBottomSheet {
+                    if success {
+                        owner.successAlarmUpdateSubject.onNext(())
+                    }
+                }
+            }
+            .disposed(by: disposeBag)
     }
     
 }
@@ -99,7 +111,7 @@ extension TicketingAlarmBottomSheetViewController {
         let cellRegistration = UICollectionView.CellRegistration<TicketingAlarmCell, TicketingAlarmCellModel> { (cell, indexPath, model) in
             cell.configureUI(with: model)
         }
-
+        
         let dataSource = UICollectionViewDiffableDataSource<TicketingAlarmViewModel.TicketingAlarmSection, TicketingAlarmCellModel>(collectionView: ticketingAlarmCollectionView) { (collectionView, indexPath, model) -> UICollectionViewCell? in
             return collectionView.dequeueConfiguredReusableCell(using: cellRegistration, for: indexPath, item: model)
         }

--- a/ShowPot/ShowPot/Common/UI/BottomSheet/TicketingAlarm/TicketingAlarmUpdateBottomSheetViewController.swift
+++ b/ShowPot/ShowPot/Common/UI/BottomSheet/TicketingAlarm/TicketingAlarmUpdateBottomSheetViewController.swift
@@ -16,6 +16,8 @@ final class TicketingAlarmUpdateBottomSheetViewController: BottomSheetViewContro
     private let disposeBag = DisposeBag()
     private let viewModel: TicketingAlarmUpdateViewModel
     
+    var successAlarmUpdateSubject = PublishSubject<Void>()
+    
     private let titleLabel = SPLabel(KRFont.H1).then {
         $0.textColor = .gray100
         $0.setText(Strings.myShowTicketBottomsheetTitle)
@@ -90,6 +92,16 @@ final class TicketingAlarmUpdateBottomSheetViewController: BottomSheetViewContro
         let output = viewModel.transform(input: input)
         output.isEnabledBottomButton
             .drive(alarmSettingButton.rx.isEnabled)
+            .disposed(by: disposeBag)
+        
+        output.alarmUpdateResult
+            .emit(with: self) { owner, success in
+                owner.dismissBottomSheet {
+                    if success {
+                        owner.successAlarmUpdateSubject.onNext(())
+                    }
+                }
+            }
             .disposed(by: disposeBag)
     }
     

--- a/ShowPot/ShowPot/Common/UI/BottomSheet/TicketingAlarm/TicketingAlarmUpdateViewModel.swift
+++ b/ShowPot/ShowPot/Common/UI/BottomSheet/TicketingAlarm/TicketingAlarmUpdateViewModel.swift
@@ -38,6 +38,7 @@ final class TicketingAlarmUpdateViewModel: ViewModelType {
     
     struct Output {
         let isEnabledBottomButton: Driver<Bool>
+        let alarmUpdateResult: Signal<Bool>
     }
     
     func transform(input: Input) -> Output {
@@ -93,7 +94,10 @@ final class TicketingAlarmUpdateViewModel: ViewModelType {
             }
             .asDriver(onErrorDriveWith: .empty())
         
-        return Output(isEnabledBottomButton: isCheckedStateDifferent)
+        return Output(
+            isEnabledBottomButton: isCheckedStateDifferent,
+            alarmUpdateResult: usecase.updateTicketingAlarmResult.asSignal(onErrorSignalWith: .empty())
+        )
     }
 }
 

--- a/ShowPot/ShowPot/Common/UI/BottomSheet/TicketingAlarm/TicketingAlarmViewModel.swift
+++ b/ShowPot/ShowPot/Common/UI/BottomSheet/TicketingAlarm/TicketingAlarmViewModel.swift
@@ -41,6 +41,7 @@ final class TicketingAlarmViewModel: ViewModelType {
     
     struct Output {
         let isEnabledBottomButton: Driver<Bool>
+        let alarmUpdateResult: Signal<Bool>
     }
     
     func transform(input: Input) -> Output {
@@ -80,7 +81,10 @@ final class TicketingAlarmViewModel: ViewModelType {
             .map { !$0.filter { $0.isEnabled && $0.isChecked }.isEmpty }
             .asDriver(onErrorDriveWith: .empty())
         
-        return Output(isEnabledBottomButton: isEnabledBottomButton)
+        return Output(
+            isEnabledBottomButton: isEnabledBottomButton,
+            alarmUpdateResult: usecase.updateTicketingAlarmResult.asSignal(onErrorSignalWith: .empty())
+        )
     }
 }
 

--- a/ShowPot/ShowPot/Domain/UseCase/MyShow/MyShowAlarmUseCase.swift
+++ b/ShowPot/ShowPot/Domain/UseCase/MyShow/MyShowAlarmUseCase.swift
@@ -9,6 +9,8 @@ import RxSwift
 import RxCocoa
 
 final class MyShowAlarmUseCase: MyShowUseCase {
+    var updateTicketingAlarmResult: RxRelay.PublishRelay<Bool> = PublishRelay<Bool>()
+    
     var ticketingAlarm: RxRelay.PublishRelay<[TicketingAlarmCellModel]> = PublishRelay<[TicketingAlarmCellModel]>()
     var showList: RxRelay.BehaviorRelay<[PerformanceInfoCollectionViewCellModel]> = BehaviorRelay<[PerformanceInfoCollectionViewCellModel]>(value: [])
     
@@ -24,6 +26,9 @@ final class MyShowAlarmUseCase: MyShowUseCase {
     
     func updateTicketingAlarm(model: [TicketingAlarmCellModel], showID: String) { // FIXME: - #6 내 공연 티켓팅정보 업데이트 API 요청
         LogHelper.debug("티켓팅 알림 업데이트 정보: \(model.filter { $0.isEnabled && $0.isChecked })\n업데이트할 공연아이디: \(showID)")
+        let result = [true, false].shuffled()[0]
+        LogHelper.debug("티켓팅 알림 업데이트 결과: \(result)")
+        updateTicketingAlarmResult.accept(result)
     }
     
     func deleteShowAlarm(indexPath: IndexPath) {

--- a/ShowPot/ShowPot/Domain/UseCase/MyShow/MyShowUseCase.swift
+++ b/ShowPot/ShowPot/Domain/UseCase/MyShow/MyShowUseCase.swift
@@ -14,6 +14,7 @@ protocol MyShowUseCase {
     
     var showList: BehaviorRelay<[PerformanceInfoCollectionViewCellModel]> { get }
     var ticketingAlarm: PublishRelay<[TicketingAlarmCellModel]> { get }
+    var updateTicketingAlarmResult: PublishRelay<Bool> { get }
     
     func fetchShowList()
     func updateTicketingAlarm(model: [TicketingAlarmCellModel], showID: String)

--- a/ShowPot/ShowPot/Presentation/Scene/Tab/Saved/ShowDetail/ShowDetailViewController.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Tab/Saved/ShowDetail/ShowDetailViewController.swift
@@ -36,7 +36,7 @@ final class ShowDetailViewController: ViewController {
         self.contentNavigationBar.titleLabel.textColor = .gray000
         self.contentNavigationBar.backgroundColor = .clear
     }
-        
+    
     override func bind() {
         
         viewHolder.seatInfoView.showSeatListView.delegate = self
@@ -45,19 +45,36 @@ final class ShowDetailViewController: ViewController {
             .subscribe(with: self) { owner, _ in
                 let isAlarmUpdatedBefore = owner.viewHolder.footerView.alarmButton.isSelected
                 
+                guard owner.viewModel.isLoggedIn else {
+                    owner.showLoginBottomSheet()
+                    return
+                }
+                
                 if isAlarmUpdatedBefore {
-                    let alarmBottmSheet = TicketingAlarmUpdateBottomSheetViewController(viewModel: TicketingAlarmUpdateViewModel(showID: owner.viewModel.showID, usecase: MyShowAlarmUseCase()))
-                    alarmBottmSheet.alarmSettingButton.rx.tap
+                    let alarmBottmSheet = TicketingAlarmUpdateBottomSheetViewController(
+                        viewModel: TicketingAlarmUpdateViewModel(
+                            showID: owner.viewModel.showID,
+                            usecase: MyShowAlarmUseCase()
+                        )
+                    )
+                    alarmBottmSheet.successAlarmUpdateSubject
                         .subscribe(onNext: { _ in
-                            alarmBottmSheet.dismissBottomSheet()
+                            SPSnackBar(contextView: owner.view, type: .alarm)
+                                .show()
                         })
                         .disposed(by: owner.disposeBag)
                     owner.presentBottomSheet(viewController: alarmBottmSheet)
                 } else {
-                    let alarmBottmSheet = TicketingAlarmBottomSheetViewController(viewModel: TicketingAlarmViewModel(showID: owner.viewModel.showID, usecase: MyShowAlarmUseCase()))
-                    alarmBottmSheet.alarmSettingButton.rx.tap
+                    let alarmBottmSheet = TicketingAlarmBottomSheetViewController(
+                        viewModel: TicketingAlarmViewModel(
+                            showID: owner.viewModel.showID,
+                            usecase: MyShowAlarmUseCase()
+                        )
+                    )
+                    alarmBottmSheet.successAlarmUpdateSubject
                         .subscribe(onNext: { _ in
-                            alarmBottmSheet.dismissBottomSheet()
+                            SPSnackBar(contextView: owner.view, type: .alarm)
+                                .show()
                         })
                         .disposed(by: owner.disposeBag)
                     owner.presentBottomSheet(viewController: alarmBottmSheet)
@@ -67,7 +84,7 @@ final class ShowDetailViewController: ViewController {
         
         let input = ShowDetailViewModel.Input(
             viewDidLoad: .just(()),
-            didTappedLikeButton: viewHolder.footerView.likeButton.rx.tap.asObservable(), 
+            didTappedLikeButton: viewHolder.footerView.likeButton.rx.tap.asObservable(),
             didTappedBackButton: contentNavigationBar.didTapLeftButton.asObservable()
         )
         let output = viewModel.transform(input: input)

--- a/ShowPot/ShowPot/Presentation/Scene/Tab/Saved/ShowDetail/ShowDetailViewModel.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Tab/Saved/ShowDetail/ShowDetailViewModel.swift
@@ -17,6 +17,10 @@ final class ShowDetailViewModel: ViewModelType {
     private let disposeBag = DisposeBag()
     let showID: String
     
+    var isLoggedIn: Bool {
+        UserDefaultsManager.shared.get(for: .isLoggedIn) ?? false
+    }
+    
     init(showID: String, coordinator: ShowDetailCoordinator, usecase: ShowDetailUseCase) {
         self.showID = showID
         self.coordinator = coordinator


### PR DESCRIPTION
<!--- 
Pull Request 제목은 반드시 아래의 형식을 따라야 합니다.
[<Category>] <issue number> <description> (e.g. "[Feature] #123 새로운 제스쳐 추가") 
-->

## Describe
<!--- 작업에 대한 간단한 설명 -->
- 알림 업데이트 혹은 설정 성공 시 스낵바 표출 
- 알림버튼 터치에 따른 로그인 상태 여부 로직 추가

## Works made
<!-- 작업한 내용을 기재합니다. 어떤 파일이 추가되었는지, 어떤 의도로 메서드를 만들었는지, 라이브러리 추가가 왜 필요했는지 등 최대한 자세하게 작성합니다. -->
- 공연상세화면 알림 설정에 따른 성공 시 스낵바를 표출
- 스낵바가 모달형식이라 기존 올라온 바텀시트 dismiss여부를 파악해 SPSnackBar의 contextView에 `공연상세`화면의 view를 넣어 스낵바를 표출하도록 함
- 알림버튼 터치 시 로그인 여부에 따라 `showLoginbottomSheet`호출

## Changes Made
<!--- 변경된 부분을 asis-tobe 형식으로 작성합니다. UI 변경이 있을 경우 반드시 모든 부분의 스크린샷을 첨부해야 하며 비즈니스 로직이 바뀌었다면 따로 적어줍니다. -->

### As-Is
<!-- 작업 이전 동작하던 부분을 기재합니다 -->
**기존 로직**
- 알림이 성공/실패되더라도 아무런 스낵바가 호출되지않고 알림 바텀시트만 dismisse됨
- 로그인되어있지않더라도 로그인을 의도하는 바텀시트가 호출되지않음

**스크린샷**
https://github.com/user-attachments/assets/9ac977e0-dab7-443f-9c52-9fca864afc7c

### To-BE
<!-- 작업 이후 변경된 부분을 기재합니다. -->
**변경 로직**
- 알림 설정 성공 시 스낵바 표출 
- 알림버튼 클릭 시 로그인되어있지않으면 로그인유도바텀시트 표출

**스크린샷**
https://github.com/user-attachments/assets/f79da181-addc-4d35-b674-a85f724bf04d


## How to Test
<!--- 작업 내용을 확인하거나 테스트 할 수 있는 방법을 기재합니다.  -->
- 공연상세화면 이동 후 `ShowDetailViewModel`의 isLoggedIn을 확인
- `isLoggedIn`이 false일 경우 로그인 유도 바텀시트 표출 확인 
- `isLoggedIn`이 true일 경우 알림 설정 이후 성공 시 스낵바 표출 확인

## Issues Resolved
<!-- 
연관된 이슈나 다른 PR이 있다면 적어줍니다. '#123' 처럼 이슈 번호만 적지 말고, 이슈 타이틀이 같이 보일 수 있도록 bulletin list로 작성합니다.
e.g.
 - #123
 - #124
-->
- #144 

## Additional context
<!--- [선택사항] 추가적으로 공유해야 할 사항이 있다면 기재합니다. -->

## References
<!--- [선택사항] 참고한 자료가 있다면 기재합니다. -->
