### PR TITLE
[FIX] #196 검색 아티스트 구독설정/실패 성공 시 스낵바, 로그인 유무에 따른 바텀시트 표출

### DIFF
--- a/ShowPot/ShowPot/Data/Network/SPArtistAPI.swift
+++ b/ShowPot/ShowPot/Data/Network/SPArtistAPI.swift
@@ -90,7 +90,8 @@ final class SPArtistAPI {
             AF.request(
                 target.url,
                 method: target.method,
-                parameters: request
+                parameters: request,
+                headers: target.header
             ).responseDecodable(of: ArtistListResponse.self) { response in
                 switch response.result {
                 case .success(let data):

--- a/ShowPot/ShowPot/Domain/UseCase/AllPerformance/DefaultAllPerformanceUseCase.swift
+++ b/ShowPot/ShowPot/Domain/UseCase/AllPerformance/DefaultAllPerformanceUseCase.swift
@@ -21,15 +21,15 @@ final class DefaultAllPerformanceUseCase: AllPerformanceUseCase {
         LogHelper.debug("전체공연 검색\n오픈예정유무: \(state.isOnlyUpcoming)\n어떤필터타입: \(state.type)")
         
         showAPI.showList(sort: state.type.rawValue, onlyOpen: state.isOnlyUpcoming)
-            .subscribe { response in
-                self.performanceList.accept(response.data.map {
+            .subscribe(with: self) { owner, response in
+                owner.performanceList.accept(response.data.map {
                     FeaturedPerformanceWithTicketOnSaleSoonCellModel(
                         showID: $0.id,
                         performanceState: $0.isOpen ? .reserving : .upcoming,
                         performanceTitle: $0.title,
                         performanceLocation: $0.location,
                         performanceImageURL: URL(string: $0.posterImageURL),
-                        performanceDate: DateFormatterFactory.dateTime.date(from: $0.ticketingAt)
+                        performanceDate: $0.isOpen ? nil : DateFormatterFactory.dateTime.date(from: $0.ticketingAt)
                     )
                 })
             }.disposed(by: disposeBag)

--- a/ShowPot/ShowPot/Domain/UseCase/Featured/DefaultFeaturedUseCase.swift
+++ b/ShowPot/ShowPot/Domain/UseCase/Featured/DefaultFeaturedUseCase.swift
@@ -62,7 +62,7 @@ final class DefaultFeaturedUseCase: SubscribeArtistUseCase, AllPerformanceUseCas
                     performanceTitle: $0.title,
                     performanceLocation: $0.location,
                     performanceImageURL: URL(string: $0.posterImageURL),
-                    performanceDate: DateFormatterFactory.dateTime.date(from: $0.ticketingAt)
+                    performanceDate: $0.isOpen ? nil : DateFormatterFactory.dateTime.date(from: $0.ticketingAt)
                 )
             })
         }

--- a/ShowPot/ShowPot/Presentation/Scene/Search/FeaturedSearchViewController.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Search/FeaturedSearchViewController.swift
@@ -94,6 +94,12 @@ final class FeaturedSearchViewController: ViewController {
                 owner.showDeleteSubscribtionSnackbar(isSuccess: isSuccess)
             }.disposed(by: disposeBag)
         
+        output.showLoginBottomSheet
+            .emit(with: self) { owner, _ in
+                owner.showLoginBottomSheet()
+            }
+            .disposed(by: disposeBag)
+        
         Observable.merge(
             viewHolder.searchKeywordResultCollectionView.rx.didScroll.map { _ in () },
             viewHolder.recentSearchCollectionView.rx.didScroll.map { _ in () },
@@ -148,11 +154,17 @@ extension FeaturedSearchViewController: UICollectionViewDelegateFlowLayout {
 
 extension FeaturedSearchViewController {
     private func showAddSubscribtionSnackbar(isSuccess: Bool) {
+        
+        guard isSuccess else { return }
+        
         SPSnackBar(contextView: self.view, type: .subscribe)
             .show()
     }
     
     private func showDeleteSubscribtionSnackbar(isSuccess: Bool) {
+        
+        guard isSuccess else { return }
+        
         let style = SnackBarStyle(
             icon: .icCheck.withTintColor(.gray200),
             message: Strings.snackbarDescriptionSubscribeDelete,

--- a/ShowPot/ShowPot/Presentation/Scene/Tab/Settings/MyArtist/MyArtistViewController.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Tab/Settings/MyArtist/MyArtistViewController.swift
@@ -57,6 +57,12 @@ final class MyArtistViewController: ViewController {
             .map { !$0 }
             .drive(viewHolder.emptyView.rx.isHidden)
             .disposed(by: disposeBag)
+        
+        output.showLoginBottomSheet
+            .emit(with: self) { owner, _ in
+                owner.showLoginBottomSheet()
+            }
+            .disposed(by: disposeBag)
     }
 }
 


### PR DESCRIPTION
<!--- 
Pull Request 제목은 반드시 아래의 형식을 따라야 합니다.
[<Category>] <issue number> <description> (e.g. "[Feature] #123 새로운 제스쳐 추가") 
-->

## Describe
<!--- 작업에 대한 간단한 설명 -->
- 검색화면에서 아티스트 구독설정/실패 성공 시에만 스낵바 표출
- 로그인 유무에 따른 바텀시트 표출

## Works made
<!-- 작업한 내용을 기재합니다. 어떤 파일이 추가되었는지, 어떤 의도로 메서드를 만들었는지, 라이브러리 추가가 왜 필요했는지 등 최대한 자세하게 작성합니다. -->
- guard문을 이용해서 구독설정/실패 성공 시에만 스낵바 표출
- 검색결과화면에서 아티스트 구독혹은 구독취소 시 로그인 유무에 따라 바텀시트 표출
- `마이페이지`화면에서 리스트가 없을 경우 보여지는 `EmptyView`를 이용해 `아티스트 구독`화면으로 넘어갈 수 있어서 이 부분에도 로그인 유무에 따른 바텀시트 로직 추가
- 공연정보에서 `예매중`상태임에도 티켓팅날짜가 보이는 부분 해결

## Changes Made
<!--- 변경된 부분을 asis-tobe 형식으로 작성합니다. UI 변경이 있을 경우 반드시 모든 부분의 스크린샷을 첨부해야 하며 비즈니스 로직이 바뀌었다면 따로 적어줍니다. -->

### As-Is
<!-- 작업 이전 동작하던 부분을 기재합니다 -->
**기존 로직**
- 아티스트 구독설정/취소 성공유무와 별개로 스낵바 표출

**시연영상**
https://github.com/user-attachments/assets/b17662ce-3c2a-4139-aa58-47d4e2e603d3


### To-BE
<!-- 작업 이후 변경된 부분을 기재합니다. -->
**변경 로직**
- 아티스트 구독설정/실패 성공 시에만 스낵바 표출 
- 아티스트 구독설정/실패 클릭 시 로그인 유무에 따른 바텀시트 표출

**시연영상**
https://github.com/user-attachments/assets/f67a02a9-f676-4ac2-9f73-c91a3bf8980b

**로그인유무에 따른 바텀시트 표출영상**
https://github.com/user-attachments/assets/c9fa8fee-ab29-42d8-b902-596a0d9e3031

**공연정보 예매중상태일 경우 티켓팅날짜 미표출**
<img src="https://github.com/user-attachments/assets/4348f5b3-0761-4ec8-b6cb-2c5d6cb3fac8" width="25%" alt="Image">

## How to Test
<!--- 작업 내용을 확인하거나 테스트 할 수 있는 방법을 기재합니다.  -->
- 검색화면에서 아티스트 구독설정/실패에 따른 UI확인 
- 구독설정/실패 성공할때 스낵바 표출되는지 확인 
- 로그인 안돼있을 시 바텀시트 표출되는지 확인

## Issues Resolved
<!-- 
연관된 이슈나 다른 PR이 있다면 적어줍니다. '#123' 처럼 이슈 번호만 적지 말고, 이슈 타이틀이 같이 보일 수 있도록 bulletin list로 작성합니다.
e.g.
 - #123
 - #124
-->
- #196 

## Additional context
<!--- [선택사항] 추가적으로 공유해야 할 사항이 있다면 기재합니다. -->

## References
<!--- [선택사항] 참고한 자료가 있다면 기재합니다. -->
