### PR TITLE
[Fix] #198 공연상세 관심등록/해제 미동작 문제 해결

### DIFF
--- a/ShowPot/ShowPot/Data/Network/SPShowAPI.swift
+++ b/ShowPot/ShowPot/Data/Network/SPShowAPI.swift
@@ -143,10 +143,14 @@ class SPShowAPI {
     
     func showDetail(showId: String) -> Observable<ShowDetailResponse> {
         let target = SPShowTargetType.showDetail(showId: showId)
-        
-        let accessToken = try? KeyChainManager.shared.read(account: .accessToken) 
         let id = UIDevice.current.identifierForVendor?.uuidString
-        let header: HTTPHeaders = ["viewIdentifier": id ?? ""]
+        
+        var header: HTTPHeaders = ["viewIdentifier": id ?? ""]
+        if let targetHeader = target.header {
+            targetHeader.forEach { headerItem in
+                header[headerItem.name] = headerItem.value
+            }
+        }
         
         return Observable.create { emitter in
             

--- a/ShowPot/ShowPot/Domain/UseCase/ShowDetail/DefaultShowDetailUseCase.swift
+++ b/ShowPot/ShowPot/Domain/UseCase/ShowDetail/DefaultShowDetailUseCase.swift
@@ -79,9 +79,9 @@ class DefaultShowDetailUseCase: ShowDetailUseCase {
     
     func updateShowInterest(showID: String) {
         apiService.updateInterest(showId: showID)
-            .subscribe { response in
-                self.updateInterestResult.onNext(response.hasInterest)
-            } 
+            .subscribe(with: self) { owner, response in
+                owner.updateInterestResult.onNext(response.hasInterest)
+            }
             .disposed(by: disposeBag)
     }
 }

--- a/ShowPot/ShowPot/Domain/UseCase/ShowDetail/DefaultShowDetailUseCase.swift
+++ b/ShowPot/ShowPot/Domain/UseCase/ShowDetail/DefaultShowDetailUseCase.swift
@@ -29,6 +29,7 @@ class DefaultShowDetailUseCase: ShowDetailUseCase {
     
     func requestShowDetailData(showID: String) {
         apiService.showDetail(showId: showID)
+            .catch { _ in return .empty() }
             .subscribe(with: self) { owner, response in
                 owner.showOverview.onNext(.init(
                     posterImageURLString: response.posterImageURL,
@@ -79,6 +80,7 @@ class DefaultShowDetailUseCase: ShowDetailUseCase {
     
     func updateShowInterest(showID: String) {
         apiService.updateInterest(showId: showID)
+            .catch { _ in return .empty() }
             .subscribe(with: self) { owner, response in
                 owner.updateInterestResult.onNext(response.hasInterest)
             }

--- a/ShowPot/ShowPot/Domain/UseCase/ShowDetail/DefaultShowDetailUseCase.swift
+++ b/ShowPot/ShowPot/Domain/UseCase/ShowDetail/DefaultShowDetailUseCase.swift
@@ -14,12 +14,12 @@ class DefaultShowDetailUseCase: ShowDetailUseCase {
     private let apiService: SPShowAPI
     
     var showOverview = BehaviorSubject<ShowDetailOverView>(value: .init(posterImageURLString: "", title: "", time: nil, location: ""))
-    var ticketList = BehaviorSubject<ShowDetailTicketInfo>(value: .init(ticketCategory: [], prereserveOpenTime: nil, normalreserveOpenTime: nil))
+    var ticketModel = BehaviorSubject<ShowDetailTicketInfo>(value: .init(ticketCategory: [], prereserveOpenTime: nil, normalreserveOpenTime: nil))
     var buttonState = BehaviorRelay<ShowDetailButtonState>(value: .init(isLiked: false, isAlarmSet: false, isAlreadyOpen: false))
-    var artistList = BehaviorSubject<[FeaturedSubscribeArtistCellModel]>(value: [])
-    var genreList = BehaviorRelay<[GenreType]>(value: [])
-    var seatList = BehaviorRelay<[SeatDetailInfo]>(value: [])
-    var updateInterestResult = PublishSubject<Bool>()
+    var artistModel = BehaviorSubject<[FeaturedSubscribeArtistCellModel]>(value: [])
+    var genreModel = BehaviorRelay<[GenreType]>(value: [])
+    var seatModel = BehaviorRelay<[SeatDetailInfo]>(value: [])
+    var updatedShowInterestResult = PublishSubject<Bool>()
     
     private let disposeBag = DisposeBag()
     
@@ -41,7 +41,7 @@ class DefaultShowDetailUseCase: ShowDetailUseCase {
                 let normalOpenTime = response.ticketingTimes.first(where: { $0.ticketingAPIType == TicketingType.normal.rawValue })
                 let preOpenTime = response.ticketingTimes.first(where: { $0.ticketingAPIType == TicketingType.pre.rawValue })
                 
-                owner.ticketList.onNext(
+                owner.ticketModel.onNext(
                     ShowDetailTicketInfo(
                         ticketCategory: response.ticketingSites.map { TicketInfo(categoryName: $0.name, link: $0.link) },
                         prereserveOpenTime: DateFormatterFactory.dateTime.date(from: preOpenTime?.ticketingAt ?? ""),
@@ -49,7 +49,7 @@ class DefaultShowDetailUseCase: ShowDetailUseCase {
                     )
                 )
                 
-                owner.artistList.onNext(response.artists.map {
+                owner.artistModel.onNext(response.artists.map {
                     FeaturedSubscribeArtistCellModel(
                         id: $0.id,
                         state: .none,
@@ -58,11 +58,11 @@ class DefaultShowDetailUseCase: ShowDetailUseCase {
                     )
                 })
                 
-                owner.genreList.accept(response.genres.compactMap {
+                owner.genreModel.accept(response.genres.compactMap {
                     GenreType(rawValue: $0.name)
                 })
                 
-                owner.seatList.accept(response.seats.map {
+                owner.seatModel.accept(response.seats.map {
                     SeatDetailInfo(
                         seatCategoryTitle: $0.seatType,
                         seatPrice: NumberformatterFactory.decimal.number(from: "\($0.price)")
@@ -82,7 +82,7 @@ class DefaultShowDetailUseCase: ShowDetailUseCase {
         apiService.updateInterest(showId: showID)
             .catch { _ in return .empty() }
             .subscribe(with: self) { owner, response in
-                owner.updateInterestResult.onNext(response.hasInterest)
+                owner.updatedShowInterestResult.onNext(response.hasInterest)
             }
             .disposed(by: disposeBag)
     }

--- a/ShowPot/ShowPot/Domain/UseCase/ShowDetail/ShowDetailUseCase.swift
+++ b/ShowPot/ShowPot/Domain/UseCase/ShowDetail/ShowDetailUseCase.swift
@@ -73,12 +73,12 @@ struct TicketInfo {
 
 protocol ShowDetailUseCase {
     var showOverview: BehaviorSubject<ShowDetailOverView> { get set }
-    var ticketList: BehaviorSubject<ShowDetailTicketInfo> { get set }
-    var artistList: BehaviorSubject<[FeaturedSubscribeArtistCellModel]> { get set }
-    var genreList: BehaviorRelay<[GenreType]> { get set }
-    var seatList: BehaviorRelay<[SeatDetailInfo]> { get set }
+    var ticketModel: BehaviorSubject<ShowDetailTicketInfo> { get set }
+    var artistModel: BehaviorSubject<[FeaturedSubscribeArtistCellModel]> { get set }
+    var genreModel: BehaviorRelay<[GenreType]> { get set }
+    var seatModel: BehaviorRelay<[SeatDetailInfo]> { get set }
     var buttonState: BehaviorRelay<ShowDetailButtonState> { get set }
-    var updateInterestResult: PublishSubject<Bool> { get set }
+    var updatedShowInterestResult: PublishSubject<Bool> { get set }
     
     func requestShowDetailData(showID: String)
     func updateShowInterest(showID: String)

--- a/ShowPot/ShowPot/Presentation/Scene/Tab/Saved/ShowDetail/ShowDetailViewController.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Tab/Saved/ShowDetail/ShowDetailViewController.swift
@@ -100,7 +100,7 @@ final class ShowDetailViewController: ViewController {
             }
             .disposed(by: disposeBag)
         
-        output.ticketBrandList
+        output.ticketBrandModel
             .asDriver(onErrorJustReturn: [])
             .drive(viewHolder.ticketInfoView.ticketSaleCollectionView.rx.items(
                 cellIdentifier: TicketSaleCollectionViewCell.reuseIdentifier,
@@ -125,7 +125,7 @@ final class ShowDetailViewController: ViewController {
             }
             .disposed(by: disposeBag)
         
-        output.artistList
+        output.artistModel
             .asDriver(onErrorJustReturn: [])
             .drive(viewHolder.artistInfoView.artistCollectionView.rx.items(
                 cellIdentifier: FeaturedSubscribeArtistCell.reuseIdentifier,
@@ -135,7 +135,7 @@ final class ShowDetailViewController: ViewController {
             }
             .disposed(by: disposeBag)
         
-        output.genreList
+        output.genreModel
             .asDriver(onErrorJustReturn: [])
             .drive(viewHolder.genreInfoView.showGenreListView.rx.items(
                 cellIdentifier: ShowGenreCell.reuseIdentifier,
@@ -145,7 +145,7 @@ final class ShowDetailViewController: ViewController {
             }
             .disposed(by: disposeBag)
         
-        output.seatList
+        output.seatModel
             .asDriver(onErrorJustReturn: [])
             .drive(viewHolder.seatInfoView.showSeatListView.rx.items(
                 cellIdentifier: ShowSeatCell.reuseIdentifier,

--- a/ShowPot/ShowPot/Presentation/Scene/Tab/Saved/ShowDetail/ShowDetailViewController.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Tab/Saved/ShowDetail/ShowDetailViewController.swift
@@ -24,19 +24,14 @@ final class ShowDetailViewController: ViewController {
         fatalError("init(coder:) has not been implemented")
     }
     
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        viewModel.requestShowDetailData()
-    }
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         viewHolderConfigure()
+        viewHolder.seatInfoView.showSeatListView.delegate = self
     }
     
     override func setupStyles() {
         super.setupStyles()
-        viewHolder.seatInfoView.showSeatListView.delegate = self
         self.setNavigationBarItem(title: Strings.showDetailTitle, leftIcon: .icArrowLeft.withTintColor(.gray000))
         self.contentNavigationBar.titleLabel.textColor = .gray000
         self.contentNavigationBar.backgroundColor = .clear
@@ -57,14 +52,47 @@ final class ShowDetailViewController: ViewController {
             .disposed(by: disposeBag)
         
         let input = ShowDetailViewModel.Input(
+            viewWillAppear: self.rx.methodInvoked(#selector(UIViewController.viewWillAppear)).map { _ in Void() },
             didTappedLikeButton: viewHolder.footerView.likeButton.rx.tap.asObservable(),
-            didTappedBackButton: contentNavigationBar.didTapLeftButton.asObservable(), 
+            didTappedBackButton: contentNavigationBar.didTapLeftButton.asObservable(),
             didTappedTicketingCell: viewHolder.ticketInfoView.ticketSaleCollectionView.rx.itemSelected.asObservable()
         )
         let output = viewModel.transform(input: input)
         
+        bindShowDetailInfo(output)
+        bindButtonState(output)
+        
+        output.showLoginBottomSheet
+            .asSignal()
+            .emit(with: self) { owner, _ in
+                owner.showLoginBottomSheet()
+            }
+            .disposed(by: disposeBag)
+    }
+    
+    private func bindButtonState(_ output: ShowDetailViewModel.Output) {
+        output.isLikeButtonSelected
+            .asDriver(onErrorDriveWith: .empty())
+            .drive(viewHolder.footerView.likeButton.rx.isSelected)
+            .disposed(by: disposeBag)
+        
+        output.alarmButtonState
+            .asDriver(onErrorDriveWith: .empty())
+            .drive(with: self) { owner, result in
+                let (isUpdatedBefore, isAlreadyOpen) = result
+                guard !isAlreadyOpen else {
+                    owner.viewHolder.footerView.alarmButton.isEnabled = false
+                    return
+                }
+                owner.viewHolder.footerView.alarmButton.isSelected = isUpdatedBefore
+            }
+            .disposed(by: disposeBag)
+    }
+    
+    private func bindShowDetailInfo(_ output: ShowDetailViewModel.Output) {
         output.showOverview
-            .subscribe(with: self) { owner, model in
+            .asDriver()
+            .drive(with: self) { owner, model in
                 guard let showTime = model.time else { return }
                 owner.viewHolder.posterImageView.setImage(urlString: model.posterImageURLString, option: .relativeHeight)
                 owner.viewHolder.titleView.titleLabel.setText(model.title)
@@ -73,7 +101,8 @@ final class ShowDetailViewController: ViewController {
             .disposed(by: disposeBag)
         
         output.ticketBrandList
-            .bind(to: viewHolder.ticketInfoView.ticketSaleCollectionView.rx.items(
+            .asDriver(onErrorJustReturn: [])
+            .drive(viewHolder.ticketInfoView.ticketSaleCollectionView.rx.items(
                 cellIdentifier: TicketSaleCollectionViewCell.reuseIdentifier,
                 cellType: TicketSaleCollectionViewCell.self)
             ) { index, item, cell in
@@ -83,7 +112,8 @@ final class ShowDetailViewController: ViewController {
             .disposed(by: disposeBag)
         
         output.ticketTimeInfo
-            .subscribe(with: self) { owner, result in
+            .asDriver()
+            .drive(with: self) { owner, result in
                 let (preDescription, normalDescription) = result
                 if let normalDescription = normalDescription {
                     owner.viewHolder.ticketInfoView.normalTicketSaleView.setData(description: DateFormatterFactory.dateWithTicketing.string(from: normalDescription))
@@ -96,7 +126,8 @@ final class ShowDetailViewController: ViewController {
             .disposed(by: disposeBag)
         
         output.artistList
-            .bind(to: viewHolder.artistInfoView.artistCollectionView.rx.items(
+            .asDriver(onErrorJustReturn: [])
+            .drive(viewHolder.artistInfoView.artistCollectionView.rx.items(
                 cellIdentifier: FeaturedSubscribeArtistCell.reuseIdentifier,
                 cellType: FeaturedSubscribeArtistCell.self)
             ) { index, item, cell in
@@ -105,7 +136,8 @@ final class ShowDetailViewController: ViewController {
             .disposed(by: disposeBag)
         
         output.genreList
-            .bind(to: viewHolder.genreInfoView.showGenreListView.rx.items(
+            .asDriver(onErrorJustReturn: [])
+            .drive(viewHolder.genreInfoView.showGenreListView.rx.items(
                 cellIdentifier: ShowGenreCell.reuseIdentifier,
                 cellType: ShowGenreCell.self)
             ) { index, item, cell in
@@ -114,7 +146,8 @@ final class ShowDetailViewController: ViewController {
             .disposed(by: disposeBag)
         
         output.seatList
-            .bind(to: viewHolder.seatInfoView.showSeatListView.rx.items(
+            .asDriver(onErrorJustReturn: [])
+            .drive(viewHolder.seatInfoView.showSeatListView.rx.items(
                 cellIdentifier: ShowSeatCell.reuseIdentifier,
                 cellType: ShowSeatCell.self)
             ) { index, item, cell in
@@ -122,27 +155,6 @@ final class ShowDetailViewController: ViewController {
                     seatCategory: item.seatCategoryTitle,
                     seatPrice: NumberformatterFactory.decimal.string(from: item.seatPrice ?? 0)
                 )
-            }
-            .disposed(by: disposeBag)
-        
-        output.isLikeButtonSelected
-            .subscribe(viewHolder.footerView.likeButton.rx.isSelected)
-            .disposed(by: disposeBag)
-        
-        output.alarmButtonState
-            .subscribe(with: self) { owner, result in
-                let (isUpdatedBefore, isAlreadyOpen) = result
-                if isAlreadyOpen {
-                    owner.viewHolder.footerView.alarmButton.isEnabled = !isAlreadyOpen
-                    return
-                }
-                owner.viewHolder.footerView.alarmButton.isSelected = isUpdatedBefore
-            }
-            .disposed(by: disposeBag)
-        
-        output.showLoginBottomSheet
-            .subscribe(with: self) { owner, _ in
-                owner.showLoginBottomSheet()
             }
             .disposed(by: disposeBag)
     }

--- a/ShowPot/ShowPot/Presentation/Scene/Tab/Saved/ShowDetail/ShowDetailViewController.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Tab/Saved/ShowDetail/ShowDetailViewController.swift
@@ -36,15 +36,13 @@ final class ShowDetailViewController: ViewController {
     
     override func setupStyles() {
         super.setupStyles()
-        
+        viewHolder.seatInfoView.showSeatListView.delegate = self
         self.setNavigationBarItem(title: Strings.showDetailTitle, leftIcon: .icArrowLeft.withTintColor(.gray000))
         self.contentNavigationBar.titleLabel.textColor = .gray000
         self.contentNavigationBar.backgroundColor = .clear
     }
     
     override func bind() {
-        viewHolder.seatInfoView.showSeatListView.delegate = self
-        
         viewHolder.footerView.alarmButton.rx.tap
             .subscribe(with: self) { owner, _ in
                 let isAlarmUpdatedBefore = owner.viewHolder.footerView.alarmButton.isSelected
@@ -139,6 +137,12 @@ final class ShowDetailViewController: ViewController {
                     return
                 }
                 owner.viewHolder.footerView.alarmButton.isSelected = isUpdatedBefore
+            }
+            .disposed(by: disposeBag)
+        
+        output.showLoginBottomSheet
+            .subscribe(with: self) { owner, _ in
+                owner.showLoginBottomSheet()
             }
             .disposed(by: disposeBag)
     }

--- a/ShowPot/ShowPot/Presentation/Scene/Tab/Saved/ShowDetail/ShowDetailViewModel.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Tab/Saved/ShowDetail/ShowDetailViewModel.swift
@@ -28,26 +28,35 @@ final class ShowDetailViewModel: ViewModelType {
     }
     
     struct Input {
+        let viewWillAppear: Observable<Void>
         let didTappedLikeButton: Observable<Void>
         let didTappedBackButton: Observable<Void>
         let didTappedTicketingCell: Observable<IndexPath>
     }
     
     struct Output {
-        var showOverview = BehaviorSubject<ShowDetailOverView>(value: .init(posterImageURLString: "", title: "", time: nil, location: ""))
-        var ticketTimeInfo = BehaviorSubject<(Date?, Date?)>(value: (nil, nil))
-        var ticketBrandList = BehaviorSubject<[String]>(value: [])
-        var artistList = BehaviorSubject<[FeaturedSubscribeArtistCellModel]>(value: [])
-        var genreList = BehaviorSubject<[GenreType]>(value: [])
-        var seatList = BehaviorSubject<[SeatDetailInfo]>(value: [])
-        var isLikeButtonSelected = BehaviorSubject<Bool>(value: false)
-        var alarmButtonState = BehaviorSubject<(isUpdatedBefore: Bool, isEnabled: Bool)>(value: (false, true))
-        var showLoginBottomSheet = PublishSubject<Void>()
+        var showOverview = BehaviorRelay<ShowDetailOverView>(value: .init(posterImageURLString: "", title: "", time: nil, location: ""))
+        var ticketTimeInfo = BehaviorRelay<(Date?, Date?)>(value: (nil, nil))
+        var ticketBrandList = BehaviorRelay<[String]>(value: [])
+        var artistList = BehaviorRelay<[FeaturedSubscribeArtistCellModel]>(value: [])
+        var genreList = BehaviorRelay<[GenreType]>(value: [])
+        var seatList = BehaviorRelay<[SeatDetailInfo]>(value: [])
+        var isLikeButtonSelected = BehaviorRelay<Bool>(value: false)
+        var alarmButtonState = BehaviorRelay<(isUpdatedBefore: Bool, isEnabled: Bool)>(value: (false, true))
+        var showLoginBottomSheet = PublishRelay<Void>()
     }
     
     func transform(input: Input) -> Output {
-        
-        let output = Output()
+        self.configureInput(input)
+        return self.createOutput(from: input)
+    }
+    
+    private func configureInput(_ input: Input) {
+        input.viewWillAppear
+            .subscribe(with: self) { owner, _ in
+                owner.usecase.requestShowDetailData(showID: owner.showID)
+            }
+            .disposed(by: disposeBag)
         
         input.didTappedTicketingCell
             .withLatestFrom(usecase.ticketList) { ($0, $1) }
@@ -62,11 +71,16 @@ final class ShowDetailViewModel: ViewModelType {
                 owner.coordinator.popViewController()
             }
             .disposed(by: disposeBag)
+    }
+    
+    private func createOutput(from input: Input) -> Output {
+        
+        let output = Output()
         
         input.didTappedLikeButton
             .subscribe(with: self) { owner, _ in
                 guard owner.isLoggedIn else {
-                    output.showLoginBottomSheet.onNext(())
+                    output.showLoginBottomSheet.accept(())
                     return
                 }
                 owner.usecase.updateShowInterest(showID: owner.showID)
@@ -78,24 +92,21 @@ final class ShowDetailViewModel: ViewModelType {
             .disposed(by: disposeBag)
         
         usecase.updateInterestResult
-            .subscribe(with: self) { owner, result in
-                LogHelper.debug("공연 관심 등록/취소 여부: \(result)")
-                output.isLikeButtonSelected.onNext(result)
-            }
+            .bind(to: output.isLikeButtonSelected)
             .disposed(by: disposeBag)
         
         usecase.buttonState
             .subscribe(with: self) { owner, state in
                 LogHelper.debug("관심등록된 공연인가 ?: \(state.isLiked)\n이전에 알림설정한 공연인가 ?: \(state.isAlarmSet)\n 이미 오픈된 공연인가: \(state.isAlreadyOpen)")
-                output.isLikeButtonSelected.onNext(state.isLiked)
-                output.alarmButtonState.onNext((state.isAlarmSet, state.isAlreadyOpen))
+                output.isLikeButtonSelected.accept(state.isLiked)
+                output.alarmButtonState.accept((state.isAlarmSet, state.isAlreadyOpen))
             }
             .disposed(by: disposeBag)
         
         usecase.ticketList
             .subscribe(with: self) { owner, model in
-                output.ticketBrandList.onNext(model.ticketCategory.map { $0.categoryName })
-                output.ticketTimeInfo.onNext((model.prereserveOpenTime, model.normalreserveOpenTime))
+                output.ticketBrandList.accept(model.ticketCategory.map { $0.categoryName })
+                output.ticketTimeInfo.accept((model.prereserveOpenTime, model.normalreserveOpenTime))
             }
             .disposed(by: disposeBag)
         
@@ -112,9 +123,5 @@ final class ShowDetailViewModel: ViewModelType {
             .disposed(by: disposeBag)
         
         return output
-    }
-    
-    func requestShowDetailData() {
-        usecase.requestShowDetailData(showID: self.showID)
     }
 }

--- a/ShowPot/ShowPot/Presentation/Scene/Tab/Saved/ShowDetail/ShowDetailViewModel.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Tab/Saved/ShowDetail/ShowDetailViewModel.swift
@@ -37,10 +37,10 @@ final class ShowDetailViewModel: ViewModelType {
     struct Output {
         var showOverview = BehaviorRelay<ShowDetailOverView>(value: .init(posterImageURLString: "", title: "", time: nil, location: ""))
         var ticketTimeInfo = BehaviorRelay<(Date?, Date?)>(value: (nil, nil))
-        var ticketBrandList = BehaviorRelay<[String]>(value: [])
-        var artistList = BehaviorRelay<[FeaturedSubscribeArtistCellModel]>(value: [])
-        var genreList = BehaviorRelay<[GenreType]>(value: [])
-        var seatList = BehaviorRelay<[SeatDetailInfo]>(value: [])
+        var ticketBrandModel = BehaviorRelay<[String]>(value: [])
+        var artistModel = BehaviorRelay<[FeaturedSubscribeArtistCellModel]>(value: [])
+        var genreModel = BehaviorRelay<[GenreType]>(value: [])
+        var seatModel = BehaviorRelay<[SeatDetailInfo]>(value: [])
         var isLikeButtonSelected = BehaviorRelay<Bool>(value: false)
         var alarmButtonState = BehaviorRelay<(isUpdatedBefore: Bool, isEnabled: Bool)>(value: (false, true))
         var showLoginBottomSheet = PublishRelay<Void>()
@@ -59,10 +59,10 @@ final class ShowDetailViewModel: ViewModelType {
             .disposed(by: disposeBag)
         
         input.didTappedTicketingCell
-            .withLatestFrom(usecase.ticketList) { ($0, $1) }
+            .withLatestFrom(usecase.ticketModel) { ($0, $1) }
             .subscribe(with: self) { owner, result in
-                let (indexPath, ticketList) = result
-                owner.coordinator.goToTicketingWebPage(link: ticketList.ticketCategory[indexPath.row].link)
+                let (indexPath, ticketModel) = result
+                owner.coordinator.goToTicketingWebPage(link: ticketModel.ticketCategory[indexPath.row].link)
             }
             .disposed(by: disposeBag)
         
@@ -92,7 +92,7 @@ final class ShowDetailViewModel: ViewModelType {
             .bind(to: output.showOverview)
             .disposed(by: disposeBag)
         
-        usecase.updateInterestResult
+        usecase.updatedShowInterestResult
             .bind(to: output.isLikeButtonSelected)
             .disposed(by: disposeBag)
         
@@ -104,23 +104,23 @@ final class ShowDetailViewModel: ViewModelType {
             }
             .disposed(by: disposeBag)
         
-        usecase.ticketList
+        usecase.ticketModel
             .subscribe(with: self) { owner, model in
-                output.ticketBrandList.accept(model.ticketCategory.map { $0.categoryName })
+                output.ticketBrandModel.accept(model.ticketCategory.map { $0.categoryName })
                 output.ticketTimeInfo.accept((model.prereserveOpenTime, model.normalreserveOpenTime))
             }
             .disposed(by: disposeBag)
         
-        usecase.artistList
-            .bind(to: output.artistList)
+        usecase.artistModel
+            .bind(to: output.artistModel)
             .disposed(by: disposeBag)
         
-        usecase.genreList
-            .bind(to: output.genreList)
+        usecase.genreModel
+            .bind(to: output.genreModel)
             .disposed(by: disposeBag)
         
-        usecase.seatList
-            .bind(to: output.seatList)
+        usecase.seatModel
+            .bind(to: output.seatModel)
             .disposed(by: disposeBag)
         
         return output

--- a/ShowPot/ShowPot/Presentation/Scene/Tab/Saved/ShowDetail/ShowDetailViewModel.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Tab/Saved/ShowDetail/ShowDetailViewModel.swift
@@ -78,6 +78,7 @@ final class ShowDetailViewModel: ViewModelType {
         let output = Output()
         
         input.didTappedLikeButton
+            .throttle(.milliseconds(500), latest: false, scheduler: ConcurrentDispatchQueueScheduler.init(qos: .default))
             .subscribe(with: self) { owner, _ in
                 guard owner.isLoggedIn else {
                     output.showLoginBottomSheet.accept(())


### PR DESCRIPTION
<!--- 
Pull Request 제목은 반드시 아래의 형식을 따라야 합니다.
[<Category>] <issue number> <description> (e.g. "[Feature] #123 새로운 제스쳐 추가") 
-->

## Describe
<!--- 작업에 대한 간단한 설명 -->
- `공연상세`화면의 `관심 등록/해제` 미동작하는 문제를 해결 

## Works made
<!-- 작업한 내용을 기재합니다. 어떤 파일이 추가되었는지, 어떤 의도로 메서드를 만들었는지, 라이브러리 추가가 왜 필요했는지 등 최대한 자세하게 작성합니다. -->
- `공연상세정보 조회` API의 누락되었던 `accessToken`관련 헤더를 추가
- `관심 등록/해제`시 비로그인 상태일때 `로그인 바텀시트`표출

## Changes Made
<!--- 변경된 부분을 asis-tobe 형식으로 작성합니다. UI 변경이 있을 경우 반드시 모든 부분의 스크린샷을 첨부해야 하며 비즈니스 로직이 바뀌었다면 따로 적어줍니다. -->

### As-Is
<!-- 작업 이전 동작하던 부분을 기재합니다 -->
**기존 로직**
``` swift
func showDetail(showId: String) -> Observable<ShowDetailResponse> {
        let target = SPShowTargetType.showDetail(showId: showId)
        let accessToken = try? KeyChainManager.shared.read(account: .accessToken) 
        let id = UIDevice.current.identifierForVendor?.uuidString
        let header: HTTPHeaders = ["viewIdentifier": id ?? ""]
//... 생략
```
* `공연상세정보 조회` API에 대한 헤더값에 `accesssToken`이 누락된 채로 호출

**동작 영상**
|관심 등록/해제 시 갱신안되는 영상|
|:-:|
https://github.com/user-attachments/assets/aa6a1592-e29d-4c34-9fc0-a5585508e84c

### To-BE
<!-- 작업 이후 변경된 부분을 기재합니다. -->
**변경 로직**
``` swift
func showDetail(showId: String) -> Observable<ShowDetailResponse> {
        let target = SPShowTargetType.showDetail(showId: showId)
        let id = UIDevice.current.identifierForVendor?.uuidString
        
        var header: HTTPHeaders = ["viewIdentifier": id ?? ""]
        if let targetHeader = target.header {
            targetHeader.forEach { headerItem in
                header[headerItem.name] = headerItem.value
            }
        }
//... 생략
```
* `공연상세정보 조회` API의 헤더값에 `accesssToken`추가

**동작 영상**
|관심 등록/해제 시 갱신 확인 영상|관심 등록/해제 시 비로그인 상태일 때|
|:-:|:-:|
https://github.com/user-attachments/assets/7476d888-fe8d-4f93-82aa-ba65d294d4c5|https://github.com/user-attachments/assets/d0091680-8afc-4804-a358-1dc2790c639a

## How to Test
<!--- 작업 내용을 확인하거나 테스트 할 수 있는 방법을 기재합니다.  -->
1. `공연 상세화면` 이동
2. `관심 등록/해제` 시도 
3. `비로그인 상태`일 때 `로그인유도 바텀시트`가 표출되는지 확인
4. `로그인 상태`일 때 화면 재진입하여도 올바르게 `관심 등록/해제`갱신되는지 확인

## Issues Resolved
<!-- 
연관된 이슈나 다른 PR이 있다면 적어줍니다. '#123' 처럼 이슈 번호만 적지 말고, 이슈 타이틀이 같이 보일 수 있도록 bulletin list로 작성합니다.
e.g.
 - #123
 - #124
-->
- #198 

## Additional context
<!--- [선택사항] 추가적으로 공유해야 할 사항이 있다면 기재합니다. -->
- #200 다음 이슈에서 언급했던 `Input/Output`패턴에 맞춰 `ViewModel`에 직접적으로 호출하는 코드를 수정하였습니다. -> [해당 커밋](https://github.com/YAPP-Github/24th-App-Team-3-iOS/commit/4181496cea5b4b623cf85901eea099767357da2e)

## References
<!--- [선택사항] 참고한 자료가 있다면 기재합니다. -->
