### PR TITLE
[Fix] #203 공연 티켓팅 알림 셀에 대한 stroke color문제 해결

### DIFF
--- a/ShowPot/ShowPot/Presentation/Scene/Tab/Saved/MyShowAlarm/CustomView/TicketingAlarmCell.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Tab/Saved/MyShowAlarm/CustomView/TicketingAlarmCell.swift
@@ -15,9 +15,7 @@ final class TicketingAlarmCell: UICollectionViewCell, ReusableCell {
     private var isChecked: Bool = false
     private var isEnabled: Bool = true
     
-    private let timeInfoLabel = SPLabel(KRFont.H2).then {
-        $0.textColor = .gray000
-    }
+    private let timeInfoLabel = SPLabel(KRFont.H2)
     
     private lazy var checkImageView = UIImageView().then {
         $0.image = .icCheckboxOff
@@ -38,6 +36,15 @@ final class TicketingAlarmCell: UICollectionViewCell, ReusableCell {
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        
+        timeInfoLabel.text = nil
+        checkImageView.image = nil
+        contentView.layer.borderColor = nil
+        disEnabledAlertLabel.removeFromSuperview()
     }
     
     private func setupStyles() {
@@ -63,23 +70,37 @@ final class TicketingAlarmCell: UICollectionViewCell, ReusableCell {
             $0.centerY.equalToSuperview()
         }
     }
+}
+
+extension TicketingAlarmCell {
+    private func updateCellStateChanges() {
+        updateLayout()
+        updateUI()
+    }
     
-    private func updateLayoutIfNeeded() {
+    private func updateLayout() {
         if !isEnabled {
-            checkImageView.removeFromSuperview()
-            checkImageView.snp.removeConstraints()
-            contentView.addSubview(disEnabledAlertLabel)
-            disEnabledAlertLabel.snp.makeConstraints {
-                $0.trailing.equalToSuperview().inset(18)
-                $0.centerY.equalToSuperview()
-                $0.leading.equalTo(timeInfoLabel)
+            if disEnabledAlertLabel.superview == nil {
+                contentView.addSubview(disEnabledAlertLabel)
+                disEnabledAlertLabel.snp.makeConstraints {
+                    $0.trailing.equalToSuperview().inset(18)
+                    $0.centerY.equalToSuperview()
+                    $0.leading.equalTo(timeInfoLabel)
+                }
             }
-            timeInfoLabel.textColor = .gray400
-            contentView.layer.borderColor = UIColor.gray500.cgColor
-            return
+            checkImageView.removeFromSuperview()
+        } else {
+            if checkImageView.superview == nil {
+                contentView.addSubview(checkImageView)
+                setupConstraints()
+            }
+            disEnabledAlertLabel.removeFromSuperview()
         }
-        
-        contentView.layer.borderColor = isChecked ? UIColor.mainOrange.cgColor : UIColor.gray500.cgColor
+    }
+    
+    private func updateUI() {
+        timeInfoLabel.textColor = isEnabled ? .gray000 : .gray400
+        contentView.layer.borderColor = isEnabled ? (isChecked ? UIColor.mainOrange.cgColor : UIColor.gray500.cgColor) : UIColor.gray500.cgColor
         checkImageView.image = isChecked ? .icCheckboxOn : .icCheckboxOff
     }
 }
@@ -112,6 +133,6 @@ extension TicketingAlarmCell {
         self.isEnabled = isEnabled
         self.isChecked = isChecked
         timeInfoLabel.setText(ticketingAlertText)
-        updateIfNeeded()
+        updateCellStateChanges()
     }
 }

--- a/ShowPot/ShowPot/Presentation/Scene/Tab/Saved/MyShowAlarm/CustomView/TicketingAlarmCell.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Tab/Saved/MyShowAlarm/CustomView/TicketingAlarmCell.swift
@@ -84,6 +84,7 @@ final class TicketingAlarmCell: UICollectionViewCell, ReusableCell {
                 $0.leading.equalTo(timeInfoLabel)
             }
             timeInfoLabel.textColor = .gray400
+            contentView.layer.borderColor = UIColor.gray500.cgColor
             return
         }
         

--- a/ShowPot/ShowPot/Presentation/Scene/Tab/Saved/MyShowAlarm/CustomView/TicketingAlarmCell.swift
+++ b/ShowPot/ShowPot/Presentation/Scene/Tab/Saved/MyShowAlarm/CustomView/TicketingAlarmCell.swift
@@ -12,17 +12,8 @@ import Then
 
 final class TicketingAlarmCell: UICollectionViewCell, ReusableCell {
     
-    private var isChecked: Bool = false {
-        didSet {
-            updateLayoutIfNeeded()
-        }
-    }
-    
-    private var isEnabled: Bool = true {
-        didSet {
-            updateLayoutIfNeeded()
-        }
-    }
+    private var isChecked: Bool = false
+    private var isEnabled: Bool = true
     
     private let timeInfoLabel = SPLabel(KRFont.H2).then {
         $0.textColor = .gray000
@@ -121,5 +112,6 @@ extension TicketingAlarmCell {
         self.isEnabled = isEnabled
         self.isChecked = isChecked
         timeInfoLabel.setText(ticketingAlertText)
+        updateIfNeeded()
     }
 }


### PR DESCRIPTION

<!--- 
Pull Request 제목은 반드시 아래의 형식을 따라야 합니다.
[<Category>] <issue number> <description> (e.g. "[Feature] #123 새로운 제스쳐 추가") 
-->

## Describe
<!--- 작업에 대한 간단한 설명 -->
- `티켓팅알림설정/변경 바텀시트`에서 해당 시간이 사용불가상태일때 `stroke color` 적용

## Works made
<!-- 작업한 내용을 기재합니다. 어떤 파일이 추가되었는지, 어떤 의도로 메서드를 만들었는지, 라이브러리 추가가 왜 필요했는지 등 최대한 자세하게 작성합니다. -->
- `티켓팅 알림`에 대한 시간이 사용불가상태일때 `strokeColor`를 `gray500`적용

## Changes Made
<!--- 변경된 부분을 asis-tobe 형식으로 작성합니다. UI 변경이 있을 경우 반드시 모든 부분의 스크린샷을 첨부해야 하며 비즈니스 로직이 바뀌었다면 따로 적어줍니다. -->

### As-Is
<!-- 작업 이전 동작하던 부분을 기재합니다 -->
**기존 로직**
``` swift
if !isEnabled {
    checkImageView.removeFromSuperview()
    checkImageView.snp.removeConstraints()
    contentView.addSubview(disEnabledAlertLabel)
    disEnabledAlertLabel.snp.makeConstraints {
        $0.trailing.equalToSuperview().inset(18)
        $0.centerY.equalToSuperview()
        $0.leading.equalTo(timeInfoLabel)
    }
    timeInfoLabel.textColor = .gray400
    return
}
```
- `사용불가상태(isEnabled == false)`일때 아무런 `strokeColor`가 적용되지않음

**스크린샷**
<img src="https://github.com/user-attachments/assets/b40191dd-3400-450f-a01f-c481f288495a" width="25%" alt="Image">

### To-BE
<!-- 작업 이후 변경된 부분을 기재합니다. -->
**변경 로직**
``` swift
if !isEnabled {
    checkImageView.removeFromSuperview()
    checkImageView.snp.removeConstraints()
    contentView.addSubview(disEnabledAlertLabel)
    disEnabledAlertLabel.snp.makeConstraints {
        $0.trailing.equalToSuperview().inset(18)
        $0.centerY.equalToSuperview()
        $0.leading.equalTo(timeInfoLabel)
    }
    timeInfoLabel.textColor = .gray400
    contentView.layer.borderColor = UIColor.gray500.cgColor <- `사용불가상태`일때 `strokeColor`를 적용
    return
}
```

**스크린샷**
<img src="https://github.com/user-attachments/assets/0e121f2d-4215-4a10-bf7b-c52b03a0e4df" width="25%" alt="Image">

## How to Test
<!--- 작업 내용을 확인하거나 테스트 할 수 있는 방법을 기재합니다.  -->
1. `공연상세`화면 이동 
2. `알림설정/변경하기`버튼 클릭
3. `티켓팅 알림 사용불가`상태일때 strokeColor가 올바르게 `gray500`이 적용됐는지 확인

## Issues Resolved
<!-- 
연관된 이슈나 다른 PR이 있다면 적어줍니다. '#123' 처럼 이슈 번호만 적지 말고, 이슈 타이틀이 같이 보일 수 있도록 bulletin list로 작성합니다.
e.g.
 - #123
 - #124
-->
- #203 

## Additional context
<!--- [선택사항] 추가적으로 공유해야 할 사항이 있다면 기재합니다. -->
- 다음 이슈를 수정하던 중 추가적으로 발견한 이슈가 존재합니다

|티켓팅 알림 선택/미선택 시 하단 잔상이 남는 이슈 영상|
|:-:|
https://github.com/user-attachments/assets/bbcc2b6a-83d7-4470-a959-90dc6a099966
- 위 영상에서 보이는 잔상문제가 `iPhone 13 mini` 시뮬레이터에서 나타나는 이슈로 보입니다(시뮬레이터에서만 나타나는 이슈일수도)

@ChoiysApple 
- 해결 아이디어가 떠오르지않아 Draft전환 후 요청드립니다 🙋🏻‍♂️

## References
<!--- [선택사항] 참고한 자료가 있다면 기재합니다. -->
[해당 이슈리스트 노션 링크](https://www.notion.so/yapp-workspace/207f15977e20479b96d051de03e75118?p=b76aa71252cd4d3aa6fa20e2972ee7dc&pm=s)
